### PR TITLE
Implement Backing Store Caching for Policies

### DIFF
--- a/app/nexus/cmd/main.go
+++ b/app/nexus/cmd/main.go
@@ -38,7 +38,9 @@ func main() {
 
 	trust.Authenticate(spiffeid)
 
+	// This also attaches to the existing backing store if any.
 	err = state.Bootstrap(source)
+
 	if err != nil {
 		if errors.Is(err, state.ErrAlreadyInitialized) {
 			log.Log().Info(appName,

--- a/app/nexus/internal/state/backend/interface.go
+++ b/app/nexus/internal/state/backend/interface.go
@@ -6,6 +6,7 @@ package backend
 
 import (
 	"context"
+	data2 "github.com/spiffe/spike-sdk-go/api/entity/data"
 
 	"github.com/spiffe/spike/app/nexus/internal/state/entity/data"
 	"github.com/spiffe/spike/pkg/store"
@@ -36,13 +37,28 @@ type Backend interface {
 	LoadSecret(ctx context.Context, path string) (*store.Secret, error)
 	// StoreAdminToken stores an admin token
 	StoreAdminToken(ctx context.Context, token string) error
-	// LoadAdminToken loads an admin token
+
+	// LoadAdminSigningToken loads an admin token
 	LoadAdminSigningToken(ctx context.Context) (string, error)
 
 	// StoreAdminRecoveryMetadata stores admin recovery metadata
 	StoreAdminRecoveryMetadata(ctx context.Context, metadata data.RecoveryMetadata) error
 	// LoadAdminRecoveryMetadata loads admin recovery metadata
 	LoadAdminRecoveryMetadata(ctx context.Context) (data.RecoveryMetadata, error)
+
+	// StorePolicy stores a policy object in the backend storage.
+	StorePolicy(ctx context.Context, policy data2.Policy) error
+
+	// LoadPolicy retrieves a policy by its ID from the backend storage.
+	// It returns the policy object and an error, if any.
+	LoadPolicy(ctx context.Context, id string) (*data2.Policy, error)
+
+	// DeletePolicy removes a policy object identified by the given ID from
+	// storage.
+	// ctx is the context for managing cancellations and timeouts.
+	// id is the identifier of the policy to delete.
+	// Returns an error, if the operation fails.
+	DeletePolicy(ctx context.Context, id string) error
 }
 
 // Config holds configuration for backend initialization
@@ -57,6 +73,3 @@ type Config struct {
 
 // Factory creates a new backend instance
 type Factory func(cfg Config) (Backend, error)
-
-// registry of available backends
-var backends = make(map[string]Factory)

--- a/app/nexus/internal/state/backend/memory/memory.go
+++ b/app/nexus/internal/state/backend/memory/memory.go
@@ -6,6 +6,7 @@ package memory
 
 import (
 	"context"
+	data2 "github.com/spiffe/spike-sdk-go/api/entity/data"
 
 	"github.com/spiffe/spike/app/nexus/internal/state/entity/data"
 	"github.com/spiffe/spike/pkg/store"
@@ -72,5 +73,23 @@ func (s *NoopStore) StoreAdminToken(_ context.Context, _ string) error {
 func (s *NoopStore) StoreSecret(
 	_ context.Context, _ string, _ store.Secret,
 ) error {
+	return nil
+}
+
+// StorePolicy stores a policy in the no-op store.
+// This implementation is a no-op and always returns nil.
+func (s *NoopStore) StorePolicy(ctx context.Context, policy data2.Policy) error {
+	return nil
+}
+
+// LoadPolicy retrieves a policy from the store by its ID.
+// This implementation always returns nil and nil error.
+func (s *NoopStore) LoadPolicy(ctx context.Context, id string) (*data2.Policy, error) {
+	return nil, nil
+}
+
+// DeletePolicy removes a policy from the no-op store by its ID.
+// This implementation is a no-op and always returns nil.
+func (s *NoopStore) DeletePolicy(ctx context.Context, id string) error {
 	return nil
 }

--- a/app/nexus/internal/state/backend/sqlite/statements.go
+++ b/app/nexus/internal/state/backend/sqlite/statements.go
@@ -12,6 +12,14 @@ CREATE TABLE IF NOT EXISTS admin_token (
 	updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE IF NOT EXISTS policies (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    spiffe_id_pattern TEXT NOT NULL,
+    path_pattern TEXT NOT NULL,
+    created_time DATETIME NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS admin_recovery_metadata (
     id INTEGER PRIMARY KEY CHECK (id = 1),
 	encrypted_root_key BLOB NOT NULL,
@@ -84,4 +92,24 @@ const querySelectAdminSigningToken = `
 SELECT nonce, encrypted_token 
 FROM admin_token 
 WHERE id = 1
+`
+
+const queryUpsertPolicy = `
+INSERT INTO policies (id, name, spiffe_id_pattern, path_pattern, created_time)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(id) DO UPDATE SET
+    name = excluded.name,
+    spiffe_id_pattern = excluded.spiffe_id_pattern,
+    path_pattern = excluded.path_pattern
+`
+
+const queryDeletePolicy = `
+DELETE FROM policies 
+WHERE id = ?
+`
+
+const queryLoadPolicy = `
+SELECT name, spiffe_id_pattern, path_pattern, created_time 
+FROM policies 
+WHERE id = ?
 `

--- a/app/nexus/internal/state/base/base_test.go
+++ b/app/nexus/internal/state/base/base_test.go
@@ -1,7 +1,5 @@
 package base
 
-// TODO: fixme.
-
 //import (
 //	"github.com/spiffe/spike/app/nexus/internal/state/store"
 //	"testing"

--- a/app/nexus/internal/state/base/path.go
+++ b/app/nexus/internal/state/base/path.go
@@ -22,6 +22,8 @@ package base
 //	    fmt.Printf("Found key: %s\n", key)
 //	}
 func ListKeys() []string {
+	// TODO: probably upon crash keys and policies are empty and need to be hydrated.
+
 	kvMu.Lock()
 	defer kvMu.Unlock()
 	return kv.List()

--- a/app/nexus/internal/state/persist/policy.go
+++ b/app/nexus/internal/state/persist/policy.go
@@ -4,4 +4,93 @@
 
 package persist
 
-// TODO: implement me.
+import (
+	"context"
+	"github.com/spiffe/spike-sdk-go/api/entity/data"
+	"github.com/spiffe/spike/app/nexus/internal/env"
+	"github.com/spiffe/spike/internal/log"
+	"github.com/spiffe/spike/pkg/retry"
+)
+
+func AsyncPersistPolicy(policy data.Policy) {
+	be := Backend()
+
+	if policy.Id != "" {
+		go func() {
+			if be == nil {
+				return // No cache available
+			}
+
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				env.DatabaseOperationTimeout(),
+			)
+			defer cancel()
+
+			if err := be.StorePolicy(ctx, policy); err != nil {
+				// Log error but continue - memory is source of truth
+				log.Log().Warn("asyncPersistPolicy",
+					"msg", "Failed to cache policy",
+					"id", policy.Id,
+					"err", err.Error(),
+				)
+			}
+		}()
+	}
+}
+
+func AsyncDeletePolicy(id string) {
+	be := Backend()
+
+	if id != "" {
+		go func() {
+			if be == nil {
+				return // No cache available
+			}
+
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				env.DatabaseOperationTimeout(),
+			)
+			defer cancel()
+
+			if err := be.DeletePolicy(ctx, id); err != nil {
+				// Log error but continue - memory is source of truth
+				log.Log().Warn("asyncDeletePolicy",
+					"msg", "Failed to delete policy from cache",
+					"id", id,
+					"err", err.Error(),
+				)
+			}
+		}()
+	}
+}
+
+func ReadPolicy(id string) *data.Policy {
+	be := Backend()
+	if be == nil {
+		return nil
+	}
+
+	retrier := retry.NewExponentialRetrier()
+	typedRetrier := retry.NewTypedRetrier[*data.Policy](retrier)
+
+	ctx, cancel := context.WithTimeout(
+		context.Background(), env.DatabaseOperationTimeout(),
+	)
+	defer cancel()
+
+	cachedPolicy, err := typedRetrier.RetryWithBackoff(ctx, func() (*data.Policy, error) {
+		return be.LoadPolicy(ctx, id)
+	})
+	if err != nil {
+		log.Log().Warn("readPolicy",
+			"msg", "Failed to load policy from cache after retries",
+			"id", id,
+			"err", err.Error(),
+		)
+		return nil
+	}
+
+	return cachedPolicy
+}

--- a/jira.xml
+++ b/jira.xml
@@ -77,6 +77,9 @@
       have sqlite as the default backing store.
       (until we implement the S3 backing store)
     </issue>
+    <issue>
+      Fix commented out tests.
+    </issue>
   </low-hanging-fruits>
   <reserved>
     <issue waitingFor="shamir-to-be-implemented-first">
@@ -271,7 +274,18 @@
       https://mtls.example.com/resource`
     </issue>
 
+    <issue kind="v1.0-requirement">
+      > 80% unit test coverage
+    </issue>
 
+    <issue kind="v1.0-requirement">
+      Fuzzing for the user-facing API
+    </issue>
+
+    <isssue kind="v1.0-requirement">
+      100% Integration test (all features will have automated integration tests
+      in all possible environments)
+    </isssue>
     <issue>
       By design, we regard memory as the source of truth.
       This means that backing store might miss some secrets.


### PR DESCRIPTION
Similar to Secrets, when a policy is created, deleted, or updated, so will the backing store.

There are some updates to be done; yet the feature is mostly stable.