### PR TITLE
Add basic lint, build and unit-test CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,5 +41,23 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: Run Tests
+      - name: Unit Tests
         run: go test -v -race -shuffle=on -coverprofile=coverage.txt ./...
+  go-vet:
+    name: Go - Vet
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Go Vet
+        run: go vet ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Unit Tests
-        run: go test -v -race -shuffle=on -coverprofile=coverage.txt ./...
+        run: go test -race -shuffle=on -coverprofile=coverage.txt ./...
   go-vet:
     name: Go - Vet
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+jobs:
+  go-build:
+    # This job effectively exists to ensure that the code can still be built
+    # with the proposed changes.
+    name: Go - Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - run: make build
+  go-unit-test:
+    name: Go - Unit Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Run Tests
+        run: go test -v -race -shuffle=on -coverprofile=coverage.txt ./...


### PR DESCRIPTION
I've kept this PR pretty basic to create a foundation for set of PRs that will add more CI/CD to SPIKE.

This PR contains the simplest CI, that on each commit to main, or to a PR open against main:

- A basic build of the SPIKE binary, to ensure that the changes have not broken the build.
- The unit test suite will be run. With the race detector, shuffling and coverage. A future PR can ship this coverage report somewhere more useful (e.g a comment on PRs, or a service like codecov)
- The Go Vet linter will be ran to catch simple issues.

You can see that this CI has run successfully on my fork: https://github.com/strideynet/spike/pull/1