### PR TITLE
use `ExponentialRetrier` for Nexus recovery

### DIFF
--- a/app/nexus/internal/env/recovery.go
+++ b/app/nexus/internal/env/recovery.go
@@ -1,0 +1,25 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package env
+
+import (
+	"os"
+	"time"
+)
+
+// RecoveryOperationTimeout returns the recovery timeout duration.
+// It reads from the SPIKE_NEXUS_RECOVERY_TIMEOUT environment variable
+//
+// If the environment variable is not set or is not a valid duration string
+// then it defaults to `0` (no timeout limit).
+func RecoveryOperationTimeout() time.Duration {
+	e := os.Getenv("SPIKE_NEXUS_RECOVERY_TIMEOUT")
+	if e != "" {
+		if d, err := time.ParseDuration(e); err == nil {
+			return d
+		}
+	}
+	return 0
+}

--- a/app/nexus/internal/initialization/recovery/recovery.go
+++ b/app/nexus/internal/initialization/recovery/recovery.go
@@ -1,9 +1,11 @@
 package recovery
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"time"
 
@@ -11,12 +13,17 @@ import (
 	"github.com/spiffe/spike-sdk-go/api/entity/v1/reqres"
 	"github.com/spiffe/spike-sdk-go/crypto"
 	network "github.com/spiffe/spike-sdk-go/net"
+	"github.com/spiffe/spike-sdk-go/retry"
 
 	"github.com/spiffe/spike/app/nexus/internal/env"
 	state "github.com/spiffe/spike/app/nexus/internal/state/base"
 	"github.com/spiffe/spike/internal/auth"
 	"github.com/spiffe/spike/internal/log"
 	"github.com/spiffe/spike/internal/net"
+)
+
+var (
+	ErrRecoveryRetry = errors.New("recovery failed; retrying")
 )
 
 // RecoverBackingStoreUsingKeeperShards iterates through keepers until
@@ -31,8 +38,10 @@ import (
 // until recovery is successful.
 //
 // The function maintains a map of successfully recovered shards from each
-// keeper to avoid duplicate processing. It waits for 5 seconds between retry
-// attempts if recovery is unsuccessful.
+// keeper to avoid duplicate processing. On failure, it retries with an
+// exponentional backoff with a max retry delay of 5 seconds.
+// The retry timeout is loaded from `env.RecoveryOperationTimeout` and
+// defaults to 0 (unlimited; no timeout).
 //
 // Parameters:
 //   - source: An X509Source used for authenticating with keeper nodes
@@ -43,13 +52,25 @@ func RecoverBackingStoreUsingKeeperShards(source *workloadapi.X509Source) {
 
 	successfulKeeperShards := make(map[string]string)
 
-	for {
+	ctx, cancel := context.WithCancel(
+		context.Background(),
+	)
+	defer cancel()
+
+	retrier := retry.NewExponentialRetrier(
+		retry.WithBackOffOptions(
+			retry.WithMaxInterval(5),
+			retry.WithMaxElapsedTime(env.RecoveryOperationTimeout()),
+		),
+	)
+
+	if err := retrier.RetryWithBackoff(ctx, func() error {
 		recoverySuccessful := iterateKeepersAndTryRecovery(
 			source, successfulKeeperShards,
 		)
 		if recoverySuccessful {
 			log.Log().Info(fName, "msg", "Recovery successful")
-			return
+			return nil
 		}
 
 		log.Log().Warn(fName, "msg", "Recovery unsuccessful. Will retry.")
@@ -57,10 +78,10 @@ func RecoverBackingStoreUsingKeeperShards(source *workloadapi.X509Source) {
 			"Successful keepers: "+string(rune(len(successfulKeeperShards))),
 		)
 		log.Log().Warn(fName, "msg", "You may need to manually bootstrap.")
-
 		log.Log().Info(fName, "msg", "Waiting for keepers to respond")
-
-		time.Sleep(5 * time.Second)
+		return ErrRecoveryRetry
+	}); err != nil {
+		log.Fatal("Recovery failed; timed out")
 	}
 }
 

--- a/docs-src/content/getting-started/configuration.md
+++ b/docs-src/content/getting-started/configuration.md
@@ -34,6 +34,7 @@ configure the SPIKE components:
 | SPIKE Nexus  | `SPIKE_NEXUS_DB_MAX_IDLE_CONNS`      | The maximum number of idle connections to the database.                                                   | `5`                                             |
 | SPIKE Nexus  | `SPIKE_NEXUS_DB_CONN_MAX_LIFETIME`   | The maximum lifetime of a database connection.                                                            | `"1h"`                                          |
 | SPIKE Nexus  | `SPIKE_NEXUS_PBKDF2_ITERATION_COUNT` | The number of iterations for the PBKDF2 key derivation function.                                          | `600000`                                        |
+| SPIKE Nexus  | `SPIKE_NEXUS_RECOVERY_TIMEOUT`       | The timeout for attempting recovery from SPIKE Keepers. 0 = unlimited                                     | `0`                                             |
 | All          | `SPIKE_SYSTEM_LOG_LEVEL`             | The log level for all SPIKE components (DEBUG, INFO, WARN, ERROR).                                        | `"DEBUG"`                                       |
 | All          | `SPIKE_TRUST_ROOT`                   | The trust root that SPIKE components use in their SVIDs and SPIFFE IDs.                                   | `"spike.ist"`                                   |
 


### PR DESCRIPTION
Replaces the fixed five second retry delay for Nexus recovery with an `ExponentialRetrier` from `spike-sdk-go`. This is related to #69 .