### PR TITLE
Get Shard Configuration from Environment

### DIFF
--- a/app/keeper/cmd/main.go
+++ b/app/keeper/cmd/main.go
@@ -40,6 +40,7 @@ func main() {
 		appName, "msg",
 		fmt.Sprintf("Started service: %s v%s", appName, config.KeeperVersion),
 	)
+
 	if err := net.ServeWithPredicate(
 		source,
 		func() { routing.HandleRoute(http.Route) },

--- a/app/nexus/internal/env/keeper.go
+++ b/app/nexus/internal/env/keeper.go
@@ -1,3 +1,7 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
 package env
 
 import (
@@ -24,11 +28,6 @@ import (
 //   - SPIKE_NEXUS_KEEPER_PEERS is not set
 //   - SPIKE_NEXUS_KEEPER_PEERS contains invalid JSON
 func Keepers() map[string]string {
-	// example:
-	// '"{"1":"https://localhost:8443",
-	//    "2":"https://localhost:8543"
-	//    "3":"https://localhost:8643"}
-
 	p := os.Getenv("SPIKE_NEXUS_KEEPER_PEERS")
 
 	if p == "" {

--- a/app/nexus/internal/env/shamir.go
+++ b/app/nexus/internal/env/shamir.go
@@ -1,0 +1,61 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package env
+
+import (
+	"os"
+	"strconv"
+)
+
+// ShamirShares returns the total number of shares to be used in Shamir's
+// Secret Sharing. It reads the value from the SPIKE_NEXUS_SHAMIR_SHARES
+// environment variable.
+//
+// Returns:
+//   - The number of shares specified in the environment variable if it's a
+//     valid positive integer
+//   - The default value of 3 if the environment variable is unset, empty,
+//     or invalid
+//
+// This determines the total number of shares that will be created when
+//
+//	splitting a secret.
+func ShamirShares() int {
+	p := os.Getenv("SPIKE_NEXUS_SHAMIR_SHARES")
+	if p != "" {
+		mv, err := strconv.Atoi(p)
+		if err == nil && mv > 0 {
+			return mv
+		}
+	}
+
+	return 3
+}
+
+// ShamirThreshold returns the minimum number of shares required to reconstruct
+// the secret in Shamir's Secret Sharing scheme.
+// It reads the value from the SPIKE_NEXUS_SHAMIR_THRESHOLD environment
+// variable.
+//
+// Returns:
+//   - The threshold specified in the environment variable if it's a valid
+//     positive integer
+//   - The default value of 2 if the environment variable is unset, empty,
+//     or invalid
+//
+// This threshold value determines how many shares are needed to recover the
+// original secret. It should be less than or equal to the total number of
+// shares (ShamirShares()).
+func ShamirThreshold() int {
+	p := os.Getenv("SPIKE_NEXUS_SHAMIR_THRESHOLD")
+	if p != "" {
+		mv, err := strconv.Atoi(p)
+		if err == nil && mv > 0 {
+			return mv
+		}
+	}
+
+	return 2
+}

--- a/app/nexus/internal/initialization/recovery/keeper.go
+++ b/app/nexus/internal/initialization/recovery/keeper.go
@@ -7,12 +7,13 @@ package recovery
 import (
 	"encoding/hex"
 	"encoding/json"
+	"net/url"
+	"os"
+
 	"github.com/cloudflare/circl/secretsharing"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	"github.com/spiffe/spike-sdk-go/api/entity/v1/reqres"
 	apiUrl "github.com/spiffe/spike-sdk-go/api/url"
-	"net/url"
-	"os"
 
 	"github.com/spiffe/spike/app/nexus/internal/env"
 	state "github.com/spiffe/spike/app/nexus/internal/state/base"
@@ -55,7 +56,7 @@ func iterateKeepersToBootstrap(
 		successfulKeepers[keeperId] = true
 		log.Log().Info(fName, "msg", "Success", "keeper_id", keeperId)
 
-		if len(successfulKeepers) == 3 {
+		if len(successfulKeepers) == env.ShamirShares() {
 			log.Log().Info(fName, "msg", "All keepers initialized")
 
 			tombstone := config.SpikeNexusTombstonePath()
@@ -116,12 +117,12 @@ func iterateKeepersAndTryRecovery(
 		}
 
 		successfulKeeperShards[keeperId] = shard
-		if len(successfulKeeperShards) != 2 {
+		if len(successfulKeeperShards) != env.ShamirThreshold() {
 			continue
 		}
 
 		ss := rawShards(successfulKeeperShards)
-		if len(ss) != 2 {
+		if len(ss) != env.ShamirThreshold() {
 			continue
 		}
 

--- a/app/nexus/internal/initialization/recovery/root_key.go
+++ b/app/nexus/internal/initialization/recovery/root_key.go
@@ -8,81 +8,86 @@ import (
 	"github.com/cloudflare/circl/group"
 	"github.com/cloudflare/circl/secretsharing"
 
+	"github.com/spiffe/spike/app/nexus/internal/env"
 	"github.com/spiffe/spike/internal/log"
 )
 
-// RecoverRootKey reconstructs the original root key from a minimum of two
-// secret shares.
-//
-// The function uses Shamir's Secret Sharing implemented in the secretsharing
-// package to reconstruct the original secret (root key) from at least two
-// shares. It works with the P256 elliptic curve as the mathematical group for
-// the secret sharing operations.
+// RecoverRootKey reconstructs the original root key from a slice of secret
+// shares. It uses Shamir's Secret Sharing scheme to recover the original
+// secret.
 //
 // Parameters:
-//   - ss [][]byte: A slice containing at least two byte slices representing
-//     the secret shares.
-//     The function currently uses only the first two shares (ss[0] and ss[1]).
+//   - ss: A slice of byte slices, where each byte slice represents a secret
+//     share
 //
 // Returns:
-//   - []byte: The reconstructed root key as a 32-byte slice. If reconstruction
-//     fails, returns an empty byte slice after logging a fatal error.
+//   - []byte: The reconstructed root key as a byte slice
 //
-// The function will log a fatal error and terminate execution if:
-//   - It fails to unmarshal any of the shares
-//   - The secret reconstruction operation fails
-//   - The reconstructed secret is nil
-//   - The marshaled reconstructed secret doesn't have the expected 32-byte
-//     length
+// The function will:
+//   - Convert each raw byte slice into a properly formatted secretsharing.Share
+//   - Assign sequential IDs to each share starting from 1
+//   - Reconstruct the original secret using the secretsharing.Recover function
+//   - Validate the recovered key has the correct length (32 bytes)
+//
+// It will log a fatal error and exit if:
+//   - Any share fails to unmarshal properly
+//   - The recovery process fails
+//   - The reconstructed key is nil
+//   - The binary representation has an incorrect length
 func RecoverRootKey(ss [][]byte) []byte {
 	const fName = "RecoverRootKey"
 
 	g := group.P256
-	firstShard := ss[0]
-	secondShard := ss[1]
-	firstShare := secretsharing.Share{
-		ID:    g.NewScalar(),
-		Value: g.NewScalar(),
-	}
-	firstShare.ID.SetUint64(1)
-	err := firstShare.Value.UnmarshalBinary(firstShard)
-	if err != nil {
-		log.FatalLn(fName + ": Failed to unmarshal share: " + err.Error())
-	}
-	secondShare := secretsharing.Share{
-		ID:    g.NewScalar(),
-		Value: g.NewScalar(),
-	}
-	secondShare.ID.SetUint64(2)
-	err = secondShare.Value.UnmarshalBinary(secondShard)
-	if err != nil {
-		log.FatalLn(fName + ": Failed to unmarshal share: " + err.Error())
+	shares := make([]secretsharing.Share, 0, len(ss))
+
+	// Process all provided shares
+	for i, shareBinary := range ss {
+		// Create a new share with sequential ID (starting from 1)
+		share := secretsharing.Share{
+			ID:    g.NewScalar(),
+			Value: g.NewScalar(),
+		}
+
+		// Set ID (1-indexed)
+		share.ID.SetUint64(uint64(i + 1))
+
+		// Unmarshal the binary data
+		err := share.Value.UnmarshalBinary(shareBinary)
+		if err != nil {
+			log.FatalLn(fName + ": Failed to unmarshal share: " + err.Error())
+		}
+
+		shares = append(shares, share)
 	}
 
-	var shares []secretsharing.Share
-	shares = append(shares, firstShare)
-	shares = append(shares, secondShare)
-
-	reconstructed, err := secretsharing.Recover(1, shares)
+	// Recover the secret
+	// The first parameter to Recover is threshold-1
+	// We need the threshold from the environment
+	threshold := env.ShamirThreshold()
+	reconstructed, err := secretsharing.Recover(uint(threshold-1), shares)
 	if err != nil {
 		log.FatalLn(fName + ": Failed to recover: " + err.Error())
 	}
 
 	if reconstructed == nil {
 		log.FatalLn(fName + ": Failed to reconstruct the root key")
-		return []byte{}
 	}
 
-	binaryRec, err := reconstructed.MarshalBinary()
-	if err != nil {
-		log.FatalLn(fName + ": Failed to marshal: " + err.Error())
-		return []byte{}
+	if reconstructed != nil {
+		binaryRec, err := reconstructed.MarshalBinary()
+		if err != nil {
+			log.FatalLn(fName + ": Failed to marshal: " + err.Error())
+			return []byte{}
+		}
+
+		// TODO: this 32 comes up a lot; move it to a symbolic constant.
+		if len(binaryRec) != 32 {
+			log.FatalLn(fName + ": Reconstructed root key has incorrect length")
+			return []byte{}
+		}
+
+		return binaryRec
 	}
 
-	if len(binaryRec) != 32 {
-		log.FatalLn(fName + ": Reconstructed root key has incorrect length")
-		return []byte{}
-	}
-
-	return binaryRec
+	return []byte{}
 }

--- a/app/nexus/internal/initialization/recovery/shamir.go
+++ b/app/nexus/internal/initialization/recovery/shamir.go
@@ -11,15 +11,16 @@ import (
 	shamir "github.com/cloudflare/circl/secretsharing"
 	"github.com/spiffe/spike-sdk-go/crypto"
 
+	"github.com/spiffe/spike/app/nexus/internal/env"
 	"github.com/spiffe/spike/internal/log"
 )
 
 func sanityCheck(secret group.Scalar, shares []shamir.Share) {
 	const fName = "sanityCheck"
 
-	t := uint(1) // Need t+1 shares to reconstruct
+	t := uint(env.ShamirThreshold() - 1) // Need t+1 shares to reconstruct
 
-	reconstructed, err := shamir.Recover(t, shares[:2])
+	reconstructed, err := shamir.Recover(t, shares[:env.ShamirThreshold()])
 	if err != nil {
 		log.FatalLn(fName + ": Failed to recover: " + err.Error())
 	}
@@ -33,8 +34,8 @@ func computeShares(finalKey []byte) (group.Scalar, []shamir.Share) {
 
 	// Initialize parameters
 	g := group.P256
-	t := uint(1) // Need t+1 shares to reconstruct
-	n := uint(3) // Total number of shares
+	t := uint(env.ShamirThreshold() - 1) // Need t+1 shares to reconstruct
+	n := uint(env.ShamirShares())        // Total number of shares
 
 	// Create secret from your 32 byte key
 	secret := g.NewScalar()

--- a/app/nexus/internal/initialization/recovery/update.go
+++ b/app/nexus/internal/initialization/recovery/update.go
@@ -1,0 +1,109 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package recovery
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/url"
+
+	"github.com/cloudflare/circl/secretsharing"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"github.com/spiffe/spike-sdk-go/api/entity/v1/reqres"
+	apiUrl "github.com/spiffe/spike-sdk-go/api/url"
+	network "github.com/spiffe/spike-sdk-go/net"
+
+	state "github.com/spiffe/spike/app/nexus/internal/state/base"
+	"github.com/spiffe/spike/internal/auth"
+	"github.com/spiffe/spike/internal/log"
+	"github.com/spiffe/spike/internal/net"
+)
+
+func mustUpdateRecoveryInfo(rk string) []secretsharing.Share {
+	const fName = "mustUpdateRecoveryInfo"
+	log.Log().Info(fName, "msg", "Updating recovery info")
+
+	decodedRootKey, err := hex.DecodeString(rk)
+	if err != nil {
+		log.FatalLn(fName + ": failed to decode root key: " + err.Error())
+	}
+	rootSecret, rootShares := computeShares(decodedRootKey)
+	sanityCheck(rootSecret, rootShares)
+
+	// Save recovery information.
+	state.SetRootKey(decodedRootKey)
+
+	return rootShares
+}
+
+func sendShardsToKeepers(
+	source *workloadapi.X509Source, keepers map[string]string,
+) {
+	const fName = "sendShardsToKeepers"
+
+	for keeperId, keeperApiRoot := range keepers {
+		u, err := url.JoinPath(
+			keeperApiRoot, string(apiUrl.SpikeKeeperUrlContribute),
+		)
+
+		if err != nil {
+			log.Log().Warn(
+				fName, "msg", "Failed to join path", "url", keeperApiRoot,
+			)
+			continue
+		}
+
+		client, err := network.CreateMtlsClientWithPredicate(
+			source, auth.IsKeeper,
+		)
+
+		if err != nil {
+			log.Log().Warn(fName,
+				"msg", "Failed to create mTLS client",
+				"err", err)
+			continue
+		}
+
+		rk := state.RootKey()
+		if rk == nil {
+			log.Log().Info(fName, "msg", "rootKey is nil; moving on...")
+			continue
+		}
+
+		rootSecret, rootShares := computeShares(rk)
+
+		sanityCheck(rootSecret, rootShares)
+
+		share := findShare(keeperId, keepers, rootShares)
+
+		contribution, err := share.Value.MarshalBinary()
+		if err != nil {
+			log.Log().Warn(fName,
+				"msg", "Failed to marshal share",
+				"err", err, "keeper_id", keeperId)
+			continue
+		}
+
+		scr := reqres.ShardContributionRequest{
+			KeeperId: keeperId,
+			Shard:    base64.StdEncoding.EncodeToString(contribution),
+		}
+		md, err := json.Marshal(scr)
+		if err != nil {
+			log.Log().Warn(fName,
+				"msg", "Failed to marshal request",
+				"err", err, "keeper_id", keeperId)
+			continue
+		}
+
+		_, err = net.Post(client, u, md)
+		if err != nil {
+			log.Log().Warn(fName, "msg",
+				"Failed to post",
+				"err", err, "keeper_id", keeperId)
+		}
+	}
+}

--- a/app/nexus/internal/route/operator/recover.go
+++ b/app/nexus/internal/route/operator/recover.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spiffe/spike-sdk-go/api/entity/v1/reqres"
 	"github.com/spiffe/spike-sdk-go/api/errors"
 
+	"github.com/spiffe/spike/app/nexus/internal/env"
 	"github.com/spiffe/spike/app/nexus/internal/initialization/recovery"
 	"github.com/spiffe/spike/internal/log"
 	"github.com/spiffe/spike/internal/net"
@@ -67,11 +68,11 @@ func RouteRecover(
 
 	shards := recovery.PilotRecoveryShards()
 
-	if len(shards) < 2 {
+	if len(shards) < env.ShamirThreshold() {
 		return errors.ErrNotFound
 	}
 
-	payload := shards[:2]
+	payload := shards[:env.ShamirThreshold()]
 
 	responseBody := net.MarshalBody(reqres.RecoverResponse{
 		Shards: payload,

--- a/app/nexus/internal/state/backend/sqlite/persist/options.go
+++ b/app/nexus/internal/state/backend/sqlite/persist/options.go
@@ -5,6 +5,7 @@
 package persist
 
 import (
+	"github.com/spiffe/spike/app/nexus/internal/env"
 	"time"
 )
 
@@ -40,10 +41,10 @@ func DefaultOptions() *Options {
 	return &Options{
 		DataDir:         ".data",
 		DatabaseFile:    "spike.db",
-		JournalMode:     "WAL",
-		BusyTimeoutMs:   5000,
-		MaxOpenConns:    10,
-		MaxIdleConns:    5,
-		ConnMaxLifetime: time.Hour,
+		JournalMode:     env.DatabaseJournalMode(),
+		BusyTimeoutMs:   env.DatabaseBusyTimeoutMs(),
+		MaxOpenConns:    env.DatabaseMaxOpenConns(),
+		MaxIdleConns:    env.DatabaseMaxIdleConns(),
+		ConnMaxLifetime: env.DatabaseConnMaxLifetimeSec(),
 	}
 }

--- a/docs-src/content/getting-started/configuration.md
+++ b/docs-src/content/getting-started/configuration.md
@@ -15,22 +15,24 @@ You can use environment variables to configure the **SPIKE** components.
 The following table lists the environment variables that you can use to
 configure the SPIKE components:
 
-| Component    | Environment Variable                 | Description                                                                                               | Default Value                                   |
-|--------------|--------------------------------------|-----------------------------------------------------------------------------------------------------------|-------------------------------------------------|
-| SPIKE Keeper | `SPIKE_KEEPER_TLS_PORT`              | The TLS port the current SPIKE Keeper instance listens on.                                                | `":8443"`                                       |
-| SPIKE Nexus  | `SPIKE_NEXUS_KEEPER_PEERS`           | A mapping that contains `[{id:keeperurl}]` collection for all SPIKE Keepers that SPIKE Nexus knows about. | "" (check `./hack/start.sh` for usage examples. |
-| SPIKE Nexus  | `SPIKE_NEXUS_TLS_PORT`               | The TLS port SPIKE Nexus listens on.                                                                      | `":8553"`                                       |
-| SPIKE Nexus  | `SPIKE_NEXUS_MAX_SECRET_VERSIONS`    | The maximum number of versions of a secret that SPIKE Nexus stores.                                       | `10`                                            |
-| SPIKE Nexus  | `SPIKE_NEXUS_BACKEND_STORE`          | The backend store SPIKE Nexus uses to store secrets (memory, s3, sqlite).                                 | `"sqlite"`                                      |
-| SPIKE Nexus  | `SPIKE_NEXUS_DB_OPERATION_TIMEOUT`   | The timeout for database operations.                                                                      | `"5s"`                                          |
-| SPIKE Nexus  | `SPIKE_NEXUS_DB_JOURNAL_MODE`        | The journal mode for the SQLite database.                                                                 | `"WAL"`                                         |
-| SPIKE Nexus  | `SPIKE_NEXUS_DB_BUSY_TIMEOUT_MS`     | The timeout for the database to wait for a lock.                                                          | `1000`                                          |
-| SPIKE Nexus  | `SPIKE_NEXUS_DB_MAX_OPEN_CONNS`      | The maximum number of open connections to the database.                                                   | `10`                                            |
-| SPIKE Nexus  | `SPIKE_NEXUS_DB_MAX_IDLE_CONNS`      | The maximum number of idle connections to the database.                                                   | `5`                                             |
-| SPIKE Nexus  | `SPIKE_NEXUS_DB_CONN_MAX_LIFETIME`   | The maximum lifetime of a database connection.                                                            | `"1h"`                                          |
-| SPIKE Nexus  | `SPIKE_NEXUS_PBKDF2_ITERATION_COUNT` | The number of iterations for the PBKDF2 key derivation function.                                          | `600000`                                        |
-| SPIKE Nexus  | `SPIKE_NEXUS_RECOVERY_TIMEOUT`       | The timeout for attempting recovery from SPIKE Keepers. 0 = unlimited                                     | `0`                                             |
-| All          | `SPIKE_SYSTEM_LOG_LEVEL`             | The log level for all SPIKE components (`"DEBUG"`, `"INFO"`, `"WARN"`, `"ERROR"`).                        | `"DEBUG"`                                       |
+| Component    | Environment Variable                 | Description                                                                                                  | Default Value                                   |
+|--------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------------|
+| SPIKE Keeper | `SPIKE_KEEPER_TLS_PORT`              | The TLS port the current SPIKE Keeper instance listens on.                                                   | `":8443"`                                       |
+| SPIKE Nexus  | `SPIKE_NEXUS_KEEPER_PEERS`           | A mapping that contains `[{id:keeperurl}]` collection for all SPIKE Keepers that SPIKE Nexus knows about.    | "" (check `./hack/start.sh` for usage examples. |
+| SPIKE Nexus  | `SPIKE_NEXUS_TLS_PORT`               | The TLS port SPIKE Nexus listens on.                                                                         | `":8553"`                                       |
+| SPIKE Nexus  | `SPIKE_NEXUS_MAX_SECRET_VERSIONS`    | The maximum number of versions of a secret that SPIKE Nexus stores.                                          | `10`                                            |
+| SPIKE Nexus  | `SPIKE_NEXUS_BACKEND_STORE`          | The backend store SPIKE Nexus uses to store secrets (memory, s3, sqlite).                                    | `"sqlite"`                                      |
+| SPIKE Nexus  | `SPIKE_NEXUS_DB_OPERATION_TIMEOUT`   | The timeout for database operations.                                                                         | `"5s"`                                          |
+| SPIKE Nexus  | `SPIKE_NEXUS_DB_JOURNAL_MODE`        | The journal mode for the SQLite database.                                                                    | `"WAL"`                                         |
+| SPIKE Nexus  | `SPIKE_NEXUS_DB_BUSY_TIMEOUT_MS`     | The timeout for the database to wait for a lock.                                                             | `1000`                                          |
+| SPIKE Nexus  | `SPIKE_NEXUS_DB_MAX_OPEN_CONNS`      | The maximum number of open connections to the database.                                                      | `10`                                            |
+| SPIKE Nexus  | `SPIKE_NEXUS_DB_MAX_IDLE_CONNS`      | The maximum number of idle connections to the database.                                                      | `5`                                             |
+| SPIKE Nexus  | `SPIKE_NEXUS_DB_CONN_MAX_LIFETIME`   | The maximum lifetime of a database connection.                                                               | `"1h"`                                          |
+| SPIKE Nexus  | `SPIKE_NEXUS_PBKDF2_ITERATION_COUNT` | The number of iterations for the PBKDF2 key derivation function.                                             | `600000`                                        |
+| SPIKE Nexus  | `SPIKE_NEXUS_RECOVERY_TIMEOUT`       | The timeout for attempting recovery from SPIKE Keepers. 0 = unlimited                                        | `0`                                             |
+| SPIKE Nexus  | `SPIKE_NEXUS_SHAMIR_SHARES`          | The toal number of shares used for secret sharding, this should be equal to the number of SPIKE Keepers too. | `3`                                             |
+| SPIKE Nexus  | `SPIKE_NEXUS_SHAMIR_THRESHOLD`       | The minimum number of shares to be able to reconstruct the root key.                                         | `2`                                             |
+| All          | `SPIKE_SYSTEM_LOG_LEVEL`             | The log level for all SPIKE components (`"DEBUG"`, `"INFO"`, `"WARN"`, `"ERROR"`).                           | `"DEBUG"`                                       |
 
 We'll add more configuration options in the future. Stay tuned.
 

--- a/jira.xml
+++ b/jira.xml
@@ -393,17 +393,6 @@
       ^ I get an error instead of a "secret not found" message.
     </issue>
     <issue>
-      these may come from the environment:
-
-      DataDir: ".data",
-      DatabaseFile: "spike.db",
-      JournalMode: "WAL",
-      BusyTimeoutMs: 5000,
-      MaxOpenConns: 10,
-      MaxIdleConns: 5,
-      ConnMaxLifetime: time.Hour,
-    </issue>
-    <issue>
       verify if the keeper has shard before resending it:
       send hash of the shard first
       if keeper says “I have it”, don’t send the actual shard.


### PR DESCRIPTION
Until now, the keeper count and the threshold count were fixed (3 keepers, where a threshold of 2 is required to recreate the root key)

This PR makes the configuration dynamic using `SPIKE_NEXUS_SHAMIR_SHARES` and `SPIKE_NEXUS_SHAMIR_THRESHOLD` environment variables.

The variables assume the original defaults (2,3) for back-compat.