### PR TITLE
Fix shamir share count calculation

### DIFF
--- a/app/nexus/internal/initialization/recovery/recovery.go
+++ b/app/nexus/internal/initialization/recovery/recovery.go
@@ -325,9 +325,12 @@ func BootstrapBackingStoreWithNewRootKey(source *workloadapi.X509Source) {
 	successfulKeepers := make(map[string]bool)
 	keepers := env.Keepers()
 
-	shamirShareCount := env.ShamirThreshold()
+	shamirShareCount := env.ShamirShares()
 	if len(keepers) != shamirShareCount {
-		log.FatalLn(fName + ": Keepers not configured correctly")
+		log.FatalLn(
+			fName+": Keepers not configured correctly.",
+			"Share count:", shamirShareCount, "Keepers:", len(keepers),
+		)
 	}
 
 	for {


### PR DESCRIPTION
This fixes SPIKE nexus sending err messages due to not being able to bootstrap due to a misassigned variable.