### PR TITLE
security(memory): implement secure memory erasing

### DIFF
--- a/app/keeper/internal/state/shard.go
+++ b/app/keeper/internal/state/shard.go
@@ -9,6 +9,8 @@ package state
 
 import (
 	"sync"
+
+	"github.com/spiffe/spike/internal/memory"
 )
 
 var shard []byte
@@ -23,6 +25,13 @@ var shardMutex sync.RWMutex
 func SetShard(s []byte) {
 	shardMutex.Lock()
 	defer shardMutex.Unlock()
+
+	// Clear the old shard if it exists
+	if shard != nil {
+		oldShard := shard
+		memory.ClearBytes(oldShard)
+	}
+
 	shard = s
 }
 

--- a/app/nexus/internal/initialization/recovery/recovery.go
+++ b/app/nexus/internal/initialization/recovery/recovery.go
@@ -21,6 +21,7 @@ import (
 	state "github.com/spiffe/spike/app/nexus/internal/state/base"
 	"github.com/spiffe/spike/app/nexus/internal/state/persist"
 	"github.com/spiffe/spike/internal/log"
+	"github.com/spiffe/spike/internal/memory"
 )
 
 var (
@@ -168,6 +169,13 @@ func RestoreBackingStoreUsingPilotShards(shards []string) {
 		}
 		decodedShards = append(decodedShards, decodedShard)
 	}
+
+	// Clear the decoded shards before returning
+	defer func() {
+		for i := range decodedShards {
+			memory.ClearBytes(decodedShards[i])
+		}
+	}()
 
 	// Recover the root key using the threshold number of shards
 	binaryRec := RecoverRootKey(decodedShards)

--- a/app/nexus/internal/initialization/recovery/root_key.go
+++ b/app/nexus/internal/initialization/recovery/root_key.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spiffe/spike/app/nexus/internal/env"
 	"github.com/spiffe/spike/internal/log"
+	"github.com/spiffe/spike/internal/memory"
 )
 
 // RecoverRootKey reconstructs the original root key from a slice of secret
@@ -36,6 +37,13 @@ import (
 //   - The binary representation has an incorrect length
 func RecoverRootKey(ss [][]byte) []byte {
 	const fName = "RecoverRootKey"
+
+	// Create deferred call to clear all input shares before returning
+	defer func() {
+		for i := range ss {
+			memory.ClearBytes(ss[i])
+		}
+	}()
 
 	g := group.P256
 	shares := make([]secretsharing.Share, 0, len(ss))

--- a/app/nexus/internal/state/base/data.go
+++ b/app/nexus/internal/state/base/data.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spiffe/spike-sdk-go/kv"
 
 	"github.com/spiffe/spike/app/nexus/internal/env"
+	"github.com/spiffe/spike/internal/memory"
 )
 
 var (
@@ -35,5 +36,12 @@ func RootKey() []byte {
 func SetRootKey(rk []byte) {
 	rootKeyMu.Lock()
 	defer rootKeyMu.Unlock()
+
+	// Clear the old root key if it exists
+	if rootKey != nil {
+		oldRootKey := rootKey
+		memory.ClearBytes(oldRootKey)
+	}
+
 	rootKey = rk
 }

--- a/internal/memory/secure.go
+++ b/internal/memory/secure.go
@@ -1,0 +1,74 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+// Package memory provides utilities for secure memory operations.
+package memory
+
+import (
+	"runtime"
+	"unsafe"
+)
+
+// Clear securely erases all bytes in the provided value by overwriting
+// its memory with zeros. This ensures sensitive data like root keys and
+// Shamir shards are properly cleaned from memory before garbage collection.
+//
+// According to NIST SP 800-88 Rev. 1 (Guidelines for Media Sanitization), 
+// a single overwrite pass with zeros is sufficient for modern storage 
+// devices, including RAM.
+//
+// Parameters:
+//   - s: A pointer to any type of data that should be securely erased
+//
+// Usage:
+//
+//	type SensitiveData struct {
+//	    Key    [32]byte
+//	    Token  string
+//	}
+//
+//	data := &SensitiveData{...}
+//	defer memory.Clear(data)
+//	// Use data...
+func Clear[T any](s *T) {
+	if s == nil {
+		return
+	}
+	
+	p := unsafe.Pointer(s)
+	size := unsafe.Sizeof(*s)
+	b := (*[1 << 30]byte)(p)[:size:size]
+	
+	// Zero out all bytes in memory
+	for i := range b {
+		b[i] = 0
+	}
+	
+	// Make sure the data is actually wiped before gc has time to interfere
+	runtime.KeepAlive(s)
+}
+
+// ClearBytes securely erases a byte slice by overwriting all bytes with zeros.
+// This is a convenience wrapper around Clear for byte slices.
+//
+// Parameters:
+//   - b: A byte slice that should be securely erased
+//
+// Usage:
+//
+//	key := []byte{...} // Sensitive cryptographic key
+//	defer memory.ClearBytes(key)
+//	// Use key...
+func ClearBytes(b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	
+	for i := range b {
+		b[i] = 0
+	}
+	
+	// Make sure the data is actually wiped before gc has time to interfere
+	runtime.KeepAlive(b)
+}

--- a/internal/memory/secure_test.go
+++ b/internal/memory/secure_test.go
@@ -1,0 +1,76 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"testing"
+)
+
+func TestClear(t *testing.T) {
+	type testStruct struct {
+		Key    [32]byte
+		Token  string
+		UserId int64
+	}
+
+	// Create test data with non-zero values
+	key := [32]byte{}
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+
+	data := &testStruct{
+		Key:    key,
+		Token:  "secret-token-value",
+		UserId: 12345,
+	}
+
+	// Call Clear on the data
+	Clear(data)
+
+	// Verify all fields are zeroed
+	for i, b := range data.Key {
+		if b != 0 {
+			t.Errorf("Expected byte at index %d to be 0, got %d", i, b)
+		}
+	}
+
+	// Note: String contents won't be zeroed directly as strings are immutable in Go
+	// The string header will point to the same backing array
+	// In a real application, sensitive strings should be stored as byte slices
+
+	if data.UserId != 0 {
+		t.Errorf("Expected UserId to be 0, got %d", data.UserId)
+	}
+}
+
+func TestClearBytes(t *testing.T) {
+	// Create a non-zero byte slice
+	bytes := make([]byte, 64)
+	for i := range bytes {
+		bytes[i] = byte(i + 1)
+	}
+
+	// Make a copy to verify later
+	original := make([]byte, len(bytes))
+	copy(original, bytes)
+
+	// Verify bytes are non-zero initially
+	for i, b := range bytes {
+		if b != original[i] {
+			t.Fatalf("Test setup issue: bytes changed before ClearBytes call")
+		}
+	}
+
+	// Call ClearBytes
+	ClearBytes(bytes)
+
+	// Verify all bytes are zeroed
+	for i, b := range bytes {
+		if b != 0 {
+			t.Errorf("Expected byte at index %d to be 0, got %d", i, b)
+		}
+	}
+}


### PR DESCRIPTION
Implements secure memory erasing for SPIKE Nexus and SPIKE Keeper

This PR addresses issue #68 by implementing secure memory erasing for sensitive data like root keys and Shamir shards.

Changes include:
- Added a new `memory` package with `Clear` and `ClearBytes` functions for secure memory erasure
- Used NIST SP 800-88 Rev. 1 guidelines for memory sanitization
- Added tests to verify memory clearing functionality
- Applied memory clearing to sensitive data structures throughout the codebase