### PR TITLE
fix: Find spire-agent in PATH first, fallback to WORKSPACE

### DIFF
--- a/hack/spire-agent-start.sh
+++ b/hack/spire-agent-start.sh
@@ -35,15 +35,32 @@ if [ -z "$JOIN_TOKEN" ]; then
     exit 1
 fi
 
+# First search in PATH
+AGENT_PATH=$(command -v spire-agent)
+
+# If not found in PATH and WORKSPACE is defined, look in WORKSPACE
+if [ ! -f "$AGENT_PATH" ] && [ -n "$WORKSPACE" ]; then
+    AGENT_PATH="${WORKSPACE}/spire/bin/spire-agent"
+    echo "spire-agent not found in PATH, trying WORKSPACE location: $AGENT_PATH"
+fi
+
+# If still not found, return error
+if [ ! -f "$AGENT_PATH" ]; then
+    echo "Error: SPIRE agent not found at $AGENT_PATH"
+    echo "Please make sure SPIRE is installed or WORKSPACE is correctly set."
+    exit 1
+fi
+
+
 # Running spire-agent as super user to read meta information of other users'
 # processes. If you are using the current user to use SPIKE only, then you
 # can run this command without sudo.
 if [ "$1" == "--use-sudo" ]; then
-  sudo "$WORKSPACE"/spire/bin/spire-agent run \
+  sudo "$AGENT_PATH" run \
     -config ./config/spire/agent/agent.conf \
     -joinToken "$JOIN_TOKEN"
 else
-  "$WORKSPACE"/spire/bin/spire-agent run \
+  "$AGENT_PATH" run \
     -config ./config/spire/agent/agent.conf \
     -joinToken "$JOIN_TOKEN"
 fi


### PR DESCRIPTION
I identified a path concatenation issue in the SPIRE Agent startup script (hack/spire-agent-start.sh). When concatenating the $WORKSPACE variable with /spire/bin/spire-agent, if the $WORKSPACE variable did not end with a / character, it would create an incorrect path, combining as binspire-agent. This was particularly observed when running through the make start command.
This pull request includes changes to the `hack/spire-agent-start.sh` script to improve the way the `spire-agent` executable is located and executed. The most important changes include searching for the `spire-agent` in the system `PATH` and handling cases where the `WORKSPACE` environment variable is defined.
