### PR TITLE
Revert "Remove duplicate code block in getting-started/guide.md"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          # go-version-file: 'go.mod'
+
+          # Specify a compatible Go version for linting
+          go-version: '1.23'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64
+          version: v1.62

--- a/app/keeper/internal/state/shard.go
+++ b/app/keeper/internal/state/shard.go
@@ -39,7 +39,9 @@ func SetShard(s *[32]byte) {
 		return
 	}
 
-	copy(shard[:], s[:])
+	for i := range s {
+		shard[i] = s[i]
+	}
 }
 
 // Shard safely retrieves the current global shard value under a read lock.

--- a/app/nexus/internal/initialization/recovery/root_key.go
+++ b/app/nexus/internal/initialization/recovery/root_key.go
@@ -117,7 +117,9 @@ func RecoverRootKey(ss []ShamirShard) *[32]byte {
 		}
 
 		var result [32]byte
-		copy(result[:], binaryRec)
+		for i := range binaryRec {
+			result[i] = binaryRec[i]
+		}
 		// Security: Zero out temporary variables before function exits.
 		for i := range binaryRec {
 			binaryRec[i] = 0

--- a/app/nexus/internal/initialization/recovery/shard.go
+++ b/app/nexus/internal/initialization/recovery/shard.go
@@ -112,7 +112,9 @@ func shardContributionResponse(
 
 	// TODO: size validation for contribution to avoid buffer overflow.
 	var c [32]byte
-	copy(c[:], contribution)
+	for i, b := range contribution {
+		c[i] = b
+	}
 	// Security: Ensure that temporary variable is zeroed out before
 	// function exits.
 	defer func() {

--- a/app/nexus/internal/initialization/recovery/update.go
+++ b/app/nexus/internal/initialization/recovery/update.go
@@ -171,7 +171,9 @@ func sendShardsToKeepers(
 
 		// Security: shard is intentionally binary (instead of string) for
 		// better memory management. Do not change its data type.
-		copy(scr.Shard[:], contribution)
+		for i, b := range contribution {
+			scr.Shard[i] = b
+		}
 
 		// Security: Ensure that the contribution is zeroed out before
 		// the next iteration.

--- a/app/spike/internal/cmd/operator/recover.go
+++ b/app/spike/internal/cmd/operator/recover.go
@@ -146,8 +146,8 @@ func newOperatorRecoverCommand(
 				err := os.WriteFile(filePath, []byte(out), 0600)
 
 				// Security: Hint gc to reclaim memory.
-				_ = encodedShard
-				_ = out
+				encodedShard = ""
+				out = ""
 				runtime.GC()
 
 				if err != nil {

--- a/docs-src/content/getting-started/guide.md
+++ b/docs-src/content/getting-started/guide.md
@@ -364,6 +364,15 @@ spike secret put /tenants/acme/credentials/db \
 # OK
 ```
 
+Then let's read the secret:
+
+```bash
+spike (feature/zola)$ spike secret get /tenants/acme/credentials/db
+pass: SPIKERocks
+username: root
+
+```
+
 Now, let's read the secret back:
 
 ```bash


### PR DESCRIPTION
Reverting the merge.

**This PR modifies areas that were intentionally designed for secure memory management and confidential computing, making it risky**.

The original PR title indicated a documentation update. While fixing the linter is acceptable (though ideally, it should have been a separate atomic PR), modifying code beyond the stated scope expands the change unnecessarily.

Linter-related code changes should ideally be addressed by the owners of those respective components.

Reverts spiffe/spike#115