### PR TITLE
120 one tag per image arch

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -5,27 +5,19 @@ on:
     types: [published]
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: docker.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
+  REPOSITORY: getspike
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
   COSIGN_EXPERIMENTAL: 1
   DOCKER_CONTENT_TRUST: 1
-  DOCKER_CONTENT_TRUST_SERVER: https://notary.docker.io
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - dockerfile: k8s/dockerfiles/pilot.Dockerfile
-            image: getspike/pilot
-          - dockerfile: k8s/dockerfiles/keeper.Dockerfile
-            image: getspike/keeper
-          - dockerfile: k8s/dockerfiles/nexus.Dockerfile
-            image: getspike/nexus
+        app: [pilot, keeper, nexus]
+        arch: [linux/amd64, linux/arm64]
     permissions:
       contents: read
       packages: write
@@ -46,15 +38,6 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.3.0
 
-      # Setup Docker Content Trust keys
-      - name: Setup DCT
-        if: github.event_name == 'release'
-        env:
-          DCT_DELEGATION_KEY: ${{ secrets.DCT_DELEGATION_KEY }}
-        run: |
-          mkdir -p ~/.docker/trust/private
-          echo "$DCT_DELEGATION_KEY" > ~/.docker/trust/private/$(echo -n "${{ env.REGISTRY }}/${{ matrix.image }}" | sha256sum | cut -d' ' -f1).key
-
       # Login to Docker Hub
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -67,86 +50,38 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.app }}
           tags: |
-            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }}
-            type=raw,value=latest
-            type=sha
-        # example tags in order: 1.2.3, 1.2, latest, sha-1234567890(git commit sha)
+            type=semver,pattern={{version}}-${{ matrix.arch }},value=${{ github.event.release.tag_name }}
+            type=semver,pattern={{major}}.{{minor}}-${{ matrix.arch }},value=${{ github.event.release.tag_name }}
+            type=raw,value=latest-${{ matrix.arch }}
+            type=sha-${{ matrix.arch }}
+            ${{ matrix.arch == 'linux/amd64' && 'type=raw,value=latest' || '' }}
+        # example tags in order: 1.2.3-linux/amd64, 1.2-linux/amd64, latest-linux/amd64, sha-1234567890(git commit sha)
+        # if arch is linux/amd64, then add latest tag
 
-      # Build and push Docker image
-      - name: Build and push
+      # Build and load Docker image
+      - name: Build and load
         uses: docker/build-push-action@v5
-        id: build-and-push
+        id: build-and-load
+        with:
+          context: .
+          file: k8s/dockerfiles/${{ matrix.app }}.Dockerfile
+          platforms: ${{ matrix.arch }}
+          load: true
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+
+      - name: Push to Docker Hub
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.DCT_DELEGATION_PASSPHRASE }}
           DOCKER_CONTENT_TRUST: 1
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'release' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache,mode=max
-          provenance: mode=max
-
-      - name: Install Notary CLI
         run: |
-          curl -L https://github.com/notaryproject/notary/releases/download/v0.6.1/notary-Linux-amd64 -o /usr/local/bin/notary
-          chmod +x /usr/local/bin/notary
-
-      - name: Sign the image using Notary
-        if: github.event_name == 'release'
-        env:
-          DCT_DELEGATION_PASSPHRASE: ${{ secrets.DCT_DELEGATION_PASSPHRASE }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -e  # Exit on any error
-          
-          export DOCKER_CONTENT_TRUST=1
-          export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE="${{ secrets.DCT_DELEGATION_PASSPHRASE }}"
-          
-          echo "Authenticating with Docker Hub..."
-          echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-          
-          echo "Checking if notary CLI is installed..."
-          if ! command -v notary &> /dev/null; then
-            echo "Error: notary CLI is not installed. Install it before proceeding."
-            exit 1
-          fi
-          
-          echo "Inspecting trust data for ${{ env.REGISTRY }}/${{ matrix.image }}..."
-          if ! docker trust inspect --pretty "${{ env.REGISTRY }}/${{ matrix.image }}"; then
-            echo "No trust data found, signing now."
-          fi
-          
-          echo "Fetching image size..."
-          MANIFEST_JSON=$(docker manifest inspect "${{ env.REGISTRY }}/${{ matrix.image }}")
-          
-          if [ -z "$MANIFEST_JSON" ] || [ "$MANIFEST_JSON" == "null" ]; then
-            echo "Error: Unable to fetch manifest for the image. Ensure the image exists and is public."
-            exit 1
-          fi
-          
-          IMAGE_SIZE=$(echo "$MANIFEST_JSON" | jq -r 'if .layers then .layers | map(.size) | add else .manifests | map(.size) | add end')
-          
-          if [ -z "$IMAGE_SIZE" ] || [ "$IMAGE_SIZE" == "null" ]; then
-            echo "Error: Unable to determine image size."
-            exit 1
-          fi
-          
-          # Extract the hash without the 'sha256:' prefix
-          DIGEST_RAW=$(echo "${{ steps.build-and-push.outputs.digest }}" | sed 's/^sha256://')
-          
-          echo "digest: $DIGEST_RAW"
-          
-          echo "Signing the image with Notary..."
-          notary -s https://notary.docker.io -d ~/.docker/trust addhash \
-            "${{ env.REGISTRY }}/${{ matrix.image }}" "${{ steps.build-and-push.outputs.digest }}" \
-            "$IMAGE_SIZE" --sha256 "$DIGEST_RAW"
-          
-          echo "Signature added successfully."
+          for tag in $(echo "${{ steps.meta.outputs.tags }}"); do
+            echo "Pushing tag: $tag"
+            docker push "${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.app }}:$tag"
+          done

--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -85,3 +85,12 @@ jobs:
             echo "Pushing tag: $tag"
             docker push "${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.app }}:$tag"
           done
+
+      - name: Sign the images with GitHub OIDC (Cosign)
+        env:
+          DIGEST: ${{ steps.build-and-load.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          echo "${TAGS}" | tr ',' '\n' | while read -r tag; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ go.work.sum
 
 # env file
 .env
+.env.*
 
 # Generated binaries.
 /keeper


### PR DESCRIPTION
DCT doesnt support multiarch with buildx. Buildx doesnt manage to sign the images when pushing directly after, we cannot also use docker trust sign command because it will invalidate other archs when pushed, we need to work with the manifastos(docker metadata) in order to achieve multiarch signed images.

We tried to opt for the right compromise which would be: a tag per arch so we dont build and push with buildx but we load it then push it while tagging