### PR TITLE
Add cache invalidation headers to API responses (#123)

### DIFF
--- a/internal/net/response.go
+++ b/internal/net/response.go
@@ -55,9 +55,10 @@ func MarshalBody(res any, w http.ResponseWriter) []byte {
 
 // Respond writes a JSON response with the specified status code and body.
 //
-// This function sets the Content-Type header to application/json, writes the
-// provided status code, and sends the response body. Any errors during writing
-// are logged but not returned to the caller.
+// This function sets the Content-Type header to application/json, adds cache
+// invalidation headers (Cache-Control, Pragma, Expires), writes the provided 
+// status code, and sends the response body. Any errors during writing are 
+// logged but not returned to the caller.
 //
 // Parameters:
 //   - statusCode: int - The HTTP status code to send
@@ -65,6 +66,12 @@ func MarshalBody(res any, w http.ResponseWriter) []byte {
 //   - w: http.ResponseWriter - The response writer to use
 func Respond(statusCode int, body []byte, w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
+
+	// Add cache invalidation headers
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+
 	w.WriteHeader(statusCode)
 
 	_, err := w.Write(body)


### PR DESCRIPTION
## Add cache invalidation headers to API responses

This PR implements issue [#123](https://github.com/spiffe/spike/issues/123) by adding cache invalidation headers to all API responses from SPIKE Nexus.

### Changes:
- Added the following cache control headers to the `Respond` function:
  - `Cache-Control: no-store, no-cache, must-revalidate, private` (with "private" directive to prevent caching in shared caches)
  - `Pragma: no-cache`
  - `Expires: 0`
- Updated the function documentation to reflect these changes

### Why:
These headers prevent browsers and proxies from caching API responses, which enhances security by ensuring clients always receive fresh data and don't use potentially outdated sensitive information from cache. The "private" directive specifically prevents shared caches (like CDNs or proxies) from storing the response, restricting caching to the end user's browser only if at all.

### Implementation details:
The changes were made in the central `Respond` function within `response.go`, which is used by all API endpoints to send responses, ensuring consistent application of these headers across the entire API.