### PR TITLE
restoration files are hex encoded now.

### DIFF
--- a/app/nexus/internal/route/operator/recover.go
+++ b/app/nexus/internal/route/operator/recover.go
@@ -72,7 +72,7 @@ func RouteRecover(
 	log.Log().Info(fName, "msg", "request is valid. Recovery shards requested.")
 	shards := recovery.NewPilotRecoveryShards()
 
-	// Security: reset shards before function exits.
+	// Security: reset shards before the function exits.
 	defer func() {
 		for i := range shards {
 			mem.ClearRawBytes(shards[i])

--- a/app/spike/cmd/main.go
+++ b/app/spike/cmd/main.go
@@ -6,7 +6,9 @@ package main
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/spiffe/spike-sdk-go/security/mem"
 	"github.com/spiffe/spike-sdk-go/spiffe"
 
 	"github.com/spiffe/spike/app/spike/internal/cmd"
@@ -14,6 +16,13 @@ import (
 )
 
 func main() {
+	if !mem.Lock() {
+		fmt.Println("")
+		fmt.Println("Memory locking is not available.")
+		fmt.Println("Consider disabling swap to enhance security.")
+		fmt.Println("")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/app/spike/internal/cmd/operator/recover.go
+++ b/app/spike/internal/cmd/operator/recover.go
@@ -5,6 +5,7 @@
 package operator
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -179,9 +180,7 @@ func newOperatorRecoverCommand(
 			for i, shard := range shards {
 				filePath := fmt.Sprintf("%s/spike.recovery.%d.txt", recoverDir, i)
 
-				ss := shard[:]
-
-				encodedShard := fmt.Sprintf("%x", ss)
+				encodedShard := base64.StdEncoding.EncodeToString(shard[:])
 
 				out := fmt.Sprintf("spike:%d:%s", i, encodedShard)
 

--- a/app/spike/internal/cmd/operator/recover.go
+++ b/app/spike/internal/cmd/operator/recover.go
@@ -5,7 +5,6 @@
 package operator
 
 import (
-	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -181,7 +180,8 @@ func newOperatorRecoverCommand(
 				filePath := fmt.Sprintf("%s/spike.recovery.%d.txt", recoverDir, i)
 
 				ss := shard[:]
-				encodedShard := base64.StdEncoding.EncodeToString(ss)
+
+				encodedShard := fmt.Sprintf("%x", ss)
 
 				out := fmt.Sprintf("spike:%d:%s", i, encodedShard)
 

--- a/app/spike/internal/cmd/operator/restore.go
+++ b/app/spike/internal/cmd/operator/restore.go
@@ -5,7 +5,7 @@
 package operator
 
 import (
-	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strconv"
@@ -101,15 +101,14 @@ func newOperatorRestoreCommand(
 			}
 
 			index := shardParts[1]
-			base64Data := shardParts[2]
+			hexData := shardParts[2]
 
-			// 32 bytes encoded in base64 should be 44 characters (including
-			// possible padding)
-			if len(base64Data) < 40 || len(base64Data) > 50 {
-				log.FatalLn("Invalid base64 shard length:", len(base64Data))
+			// 32 bytes encoded in hex should be 64 characters
+			if len(hexData) != 64 {
+				log.FatalLn("Invalid hex shard length:", len(hexData))
 			}
 
-			decodedShard, err := base64.StdEncoding.DecodeString(base64Data)
+			decodedShard, err := hex.DecodeString(hexData)
 
 			// Security: Use defer for cleanup to ensure it happens even in
 			// error paths

--- a/app/spike/internal/cmd/operator/restore.go
+++ b/app/spike/internal/cmd/operator/restore.go
@@ -105,12 +105,13 @@ func newOperatorRestoreCommand(
 
 			// 32 bytes encoded in hex should be 64 characters
 			if len(hexData) != 64 {
-				log.FatalLn("Invalid hex shard length:", len(hexData))
+				log.FatalLn("Invalid hex shard length:", len(hexData),
+					" (expected 64 characters). Did miss some characters when pasting?")
 			}
 
 			decodedShard, err := hex.DecodeString(hexData)
 
-			// Security: Use defer for cleanup to ensure it happens even in
+			// Security: Use `defer` for cleanup to ensure it happens even in
 			// error paths
 			defer func() {
 				mem.ClearBytes(shard)

--- a/docs-src/content/tracking/changelog.md
+++ b/docs-src/content/tracking/changelog.md
@@ -14,6 +14,7 @@ sort_by = "weight"
 
 * Fixed: Doomsday recovery was not immediately restoring data from the backing
   store. Now it does.
+* Better shard sanitization during doomsday recovery operation.
 
 ## [0.4.0] - 2025-04-16
 
@@ -22,7 +23,7 @@ sort_by = "weight"
 * Added more configuration options to SPIKE Nexus.
 * Updated documentation around security and production hardening.
 * Updated release instructions, added a series of tests to follow and cutting
-  a release only after all tests pass. These test are manual for now, but
+  a release only after all tests pass. These tests are manual for now, but
   can be automated later down the line.
 
 ### Fixed

--- a/docs-src/content/tracking/changelog.md
+++ b/docs-src/content/tracking/changelog.md
@@ -15,6 +15,8 @@ sort_by = "weight"
 * Fixed: Doomsday recovery was not immediately restoring data from the backing
   store. Now it does.
 * Better shard sanitization during doomsday recovery operation.
+* Added memory locking to SPIKE Pilot too (along with SPIKE Nexus and 
+  SPIKE Keeper, which already had memory locking)
 
 ## [0.4.0] - 2025-04-16
 

--- a/jira.xml
+++ b/jira.xml
@@ -39,11 +39,6 @@
   <immediate-backlog>
     <meta>Things to do before working further on containerization.</meta>
     <issue>
-      provide the restore txt files in hex form so that it will be much easier
-      to sanitize, validate length etc. to validate a base64 encoded text is
-      error-prone.
-    </issue>
-    <issue>
       if keepers are not up after a doomsday recovery
       spike secret list and spike policy list return empty although database is full.
       we might need an early recovery (but need to think about that too)


### PR DESCRIPTION
Instead of base64.

Yes, it's more data, but it has same length at all times, so it's less error-prone during copy-paste, and easier to sanitizer.