### PR TITLE
Stricter pattern matching for Secret and Policy Operations

### DIFF
--- a/app/nexus/internal/route/acl/policy/create_intercept.go
+++ b/app/nexus/internal/route/acl/policy/create_intercept.go
@@ -43,9 +43,10 @@ func guardPutPolicyRequest(
 		return apiErr.ErrUnauthorized
 	}
 
+	// Request "write" access to the ACL system for the SPIFFE ID.
 	allowed := state.CheckAccess(
-		spiffeid.String(), "*",
-		[]data.PolicyPermission{data.PermissionSuper},
+		spiffeid.String(), "spike/system/acl",
+		[]data.PolicyPermission{data.PermissionWrite},
 	)
 	if !allowed {
 		responseBody := net.MarshalBody(reqres.PolicyCreateResponse{

--- a/app/nexus/internal/route/acl/policy/delete_intercept.go
+++ b/app/nexus/internal/route/acl/policy/delete_intercept.go
@@ -54,8 +54,8 @@ func guardDeletePolicyRequest(
 	}
 
 	allowed := state.CheckAccess(
-		spiffeid.String(), "*",
-		[]data.PolicyPermission{data.PermissionSuper},
+		spiffeid.String(), "spike/system/acl",
+		[]data.PolicyPermission{data.PermissionWrite},
 	)
 	if !allowed {
 		responseBody := net.MarshalBody(reqres.PolicyDeleteResponse{

--- a/app/nexus/internal/route/acl/policy/list_intercept.go
+++ b/app/nexus/internal/route/acl/policy/list_intercept.go
@@ -39,8 +39,8 @@ func guardListPolicyRequest(
 	}
 
 	allowed := state.CheckAccess(
-		spiffeid.String(), "*",
-		[]data.PolicyPermission{data.PermissionSuper},
+		spiffeid.String(), "spike/system/acl",
+		[]data.PolicyPermission{data.PermissionList},
 	)
 	if !allowed {
 		responseBody := net.MarshalBody(reqres.PolicyListResponse{

--- a/app/nexus/internal/route/acl/policy/read_intercept.go
+++ b/app/nexus/internal/route/acl/policy/read_intercept.go
@@ -52,8 +52,8 @@ func guardReadPolicyRequest(
 	}
 
 	allowed := state.CheckAccess(
-		spiffeid.String(), "*",
-		[]data.PolicyPermission{data.PermissionSuper},
+		spiffeid.String(), "spike/system/acl",
+		[]data.PolicyPermission{data.PermissionRead},
 	)
 	if !allowed {
 		responseBody := net.MarshalBody(reqres.PolicyReadResponse{

--- a/app/nexus/internal/route/operator/recover_intercept.go
+++ b/app/nexus/internal/route/operator/recover_intercept.go
@@ -28,7 +28,7 @@ func guardRecoverRequest(
 		return apiErr.ErrUnauthorized
 	}
 
-	if peerSpiffeId.String() != spiffeid.SpikePilotRecover() {
+	if !spiffeid.IsPilotRecover(peerSpiffeId.String()) {
 		responseBody := net.MarshalBody(reqres.RestoreResponse{
 			Err: data.ErrUnauthorized,
 		}, w)

--- a/app/nexus/internal/route/operator/restore_intercept.go
+++ b/app/nexus/internal/route/operator/restore_intercept.go
@@ -28,7 +28,7 @@ func guardRestoreRequest(
 		return apiErr.ErrUnauthorized
 	}
 
-	if peerSpiffeid.String() != spiffeid.SpikePilotRestore() {
+	if !spiffeid.IsPilotRestore(peerSpiffeid.String()) {
 		responseBody := net.MarshalBody(reqres.RestoreResponse{
 			Err: data.ErrUnauthorized,
 		}, w)

--- a/app/nexus/internal/route/secret/list_intercept.go
+++ b/app/nexus/internal/route/secret/list_intercept.go
@@ -40,7 +40,7 @@ func guardListSecretRequest(
 	}
 
 	allowed := state.CheckAccess(
-		spiffeid.String(), "*",
+		spiffeid.String(), "spike/system/secrets",
 		[]data.PolicyPermission{data.PermissionList},
 	)
 	if !allowed {

--- a/app/nexus/internal/state/base/policy.go
+++ b/app/nexus/internal/state/base/policy.go
@@ -49,7 +49,7 @@ var (
 func CheckAccess(
 	peerSpiffeId string, path string, wants []data.PolicyPermission,
 ) bool {
-	// Role:SpikePilot can always manage secrets.
+	// Role:SpikePilot can always manage secrets and policies.
 	if spiffeid.IsPilot(peerSpiffeId) {
 		return true
 	}


### PR DESCRIPTION
This PR introduces two predefined namespaces for policy-mangement purposes:

* `spike/system/acl`
* `spike/system/secrets`

These don't have any effect if the user is an administrator with a SPIKE Pilot SVID (SPIKE Pilot can CRUD policies and secrets with no restriction)

However, if we want to allow an arbitrary workload to, say, for example, list policies; then the workload will need to have a policy that defines LIST access for `spike/system/acl`.

We need this special `spike/system/secrets` path because the meta information about all secrets do not reside in a path, it is more like a schema-level operation as in "list all the secret paths in the system" -- so we assume we maintain a list of paths (and maybe other meta information in the future, too) under the pseudo `spike/system/secrets` paths, for convenience.

For policies, we have a similar issue. Policies don't have paths, so we consider all of them stay under the pseudo `spike/system/acl` path instead.

 because, technically, secrets (and policies)
do not live under a path--they themselves have paths, but Nexus REST API does not allow things like "list all secrets that are under a given path"