### PR TITLE
fix orphaned spike processes by adding exec command to scripts

### DIFF
--- a/hack/bare-metal/startup/start-keeper-1.sh
+++ b/hack/bare-metal/startup/start-keeper-1.sh
@@ -3,4 +3,4 @@
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
 SPIKE_KEEPER_TLS_PORT=':8443' \
-./keeper
+exec ./keeper

--- a/hack/bare-metal/startup/start-keeper-2.sh
+++ b/hack/bare-metal/startup/start-keeper-2.sh
@@ -3,4 +3,4 @@
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
 SPIKE_KEEPER_TLS_PORT=':8543' \
-./keeper
+exec ./keeper

--- a/hack/bare-metal/startup/start-keeper-3.sh
+++ b/hack/bare-metal/startup/start-keeper-3.sh
@@ -3,4 +3,4 @@
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
 SPIKE_KEEPER_TLS_PORT=':8643' \
-./keeper
+exec ./keeper

--- a/hack/bare-metal/startup/start-nexus.sh
+++ b/hack/bare-metal/startup/start-nexus.sh
@@ -5,4 +5,4 @@
 # The SPIKE Keeper peer address mappings MUST start with the key "1" and they MUST
 # increment by 1 for each subsequent SPIKE Keeper.
 SPIKE_NEXUS_KEEPER_PEERS='https://localhost:8443,https://localhost:8543,https://localhost:8643' \
-./nexus
+exec ./nexus


### PR DESCRIPTION
When running the startup script (`hack/bare-metal/startup/start.sh`) and terminating with Ctrl+C, SPIKE processes (Keeper and Nexus) were not being properly cleaned up and continued running as orphaned processes. Because the PID trapped is the wrapper script's PID so actual processes are not killed.

I still don't know why it's not happening for SPIRE Server and SPIRE Agent binaries but adding `exec` to SPIKE start scripts fixed it for me.