### PR TITLE
Using yaml file for policy creation

### DIFF
--- a/app/spike/internal/cmd/policy/apply.go
+++ b/app/spike/internal/cmd/policy/apply.go
@@ -1,0 +1,195 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	spike "github.com/spiffe/spike-sdk-go/api"
+	"github.com/spiffe/spike/app/spike/internal/trust"
+)
+
+// normalizePath removes trailing slashes and ensures consistent path format
+func normalizePath(path string) string {
+	if path == "" {
+		return path
+	}
+
+	// Remove all trailing slashes except for root path
+	if path != "/" {
+		path = strings.TrimRight(path, "/")
+	}
+
+	return path
+}
+
+// newPolicyApplyCommand creates a new Cobra command for policy application.
+// It allows users to apply policies via the command line by specifying
+// the policy name, SPIFFE ID pattern, path pattern, and permissions either
+// through command line flags or by reading from a YAML file.
+//
+// The command uses upsert semantics - it will update an existing policy if one
+// exists with the same name, or create a new policy if it doesn't exist.
+//
+// The command requires an X509Source for SPIFFE authentication and validates
+// that the system is initialized before applying a policy.
+//
+// Parameters:
+//   - source: SPIFFE X.509 SVID source for authentication
+//   - spiffeId: The SPIFFE ID to authenticate with
+//
+// Returns:
+//   - *cobra.Command: Configured Cobra command for policy application
+//
+// Command flags:
+//   - --name: Name of the policy (required if not using --file)
+//   - --spiffeid: SPIFFE ID pattern for workload matching (required if not using --file)
+//   - --path: Path pattern for access control (required if not using --file)
+//   - --permissions: Comma-separated list of permissions (required if not using --file)
+//   - --file: Path to YAML file containing policy configuration
+//
+// Valid permissions:
+//   - read: Permission to read secrets
+//   - write: Permission to create, update, or delete secrets
+//   - list: Permission to list resources
+//   - super: Administrative permissions
+//
+// Example usage with flags:
+//
+//	spike policy apply \
+//	    --name "web-service-policy" \
+//	    --spiffeid "spiffe://example.org/web-service/*" \
+//	    --path "secrets/web/database" \
+//	    --permissions "read,write"
+//
+// Example usage with YAML file:
+//
+//	spike policy apply --file policy.yaml
+//
+// Example YAML file structure:
+//
+//	name: web-service-policy
+//	spiffeid: spiffe://example.org/web-service/*
+//	path: secrets/web/database
+//	permissions:
+//	  - read
+//	  - write
+//
+// The command will:
+//  1. Validate that all required parameters are provided (either via flags or file)
+//  2. Normalize the path pattern (remove trailing slashes)
+//  3. Check if the system is initialized
+//  4. Validate permissions and convert to the expected format
+//  5. Apply the policy using upsert semantics (create if new, update if exists)
+//
+// Error conditions:
+//   - Missing required flags (when not using --file)
+//   - Invalid permissions specified
+//   - System not initialized (requires running 'spike init' first)
+//   - Invalid SPIFFE ID pattern
+//   - Policy application failure
+//   - File reading errors (when using --file)
+//   - Invalid YAML format
+
+func newPolicyApplyCommand(
+	source *workloadapi.X509Source, spiffeId string,
+) *cobra.Command {
+	var (
+		name            string
+		pathPattern     string
+		spiffeIdPattern string
+		permsStr        string
+		filePath        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply a policy configuration",
+		Long: `Apply a policy that grants specific permissions to workloads.
+
+        Example using YAML file:
+        spike policy apply --file=policy.yaml
+
+        Example YAML file structure:
+        name: db-access
+        spiffeid: spiffe://example.org/service/*
+        path: secrets/database/production
+        permissions:
+          - read
+          - write
+
+        Valid permissions: read, write, list, super`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			var policy PolicySpec
+			var err error
+
+			// Determine if we're using file-based or flag-based input
+			if filePath != "" {
+				// Read policy from YAML file
+				policy, err = readPolicyFromFile(filePath)
+				if err != nil {
+					fmt.Printf("Error reading policy file: %v\n", err)
+					return
+				}
+			} else {
+				// Use flag-based input
+				policy, err = getPolicyFromFlags(name, spiffeIdPattern, pathPattern, permsStr)
+				if err != nil {
+					fmt.Printf("Error: %v\n", err)
+					return
+				}
+			}
+
+			// Normalize the path pattern
+			policy.Path = normalizePath(policy.Path)
+
+			// Convert permissions slice to comma-separated string for validation
+			permsStr := ""
+			if len(policy.Permissions) > 0 {
+				for i, perm := range policy.Permissions {
+					if i > 0 {
+						permsStr += ","
+					}
+					permsStr += perm
+				}
+			}
+
+			trust.Authenticate(spiffeId)
+			api := spike.NewWithSource(source)
+
+			// Validate permissions
+			permissions, err := validatePermissions(permsStr)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				return
+			}
+
+			// Apply policy using upsert semantics
+			err = api.CreatePolicy(policy.Name, policy.SpiffeID, policy.Path, permissions)
+			if handleAPIError(err) {
+				return
+			}
+
+			fmt.Printf("Policy '%s' applied successfully\n", policy.Name)
+		},
+	}
+
+	// Define flags
+	cmd.Flags().StringVar(&name, "name", "", "Policy name (required if not using --file)")
+	cmd.Flags().StringVar(&pathPattern, "path", "",
+		"Resource path pattern, e.g., 'secrets/database/production' (required if not using --file)")
+	cmd.Flags().StringVar(&spiffeIdPattern, "spiffeid", "",
+		"SPIFFE ID pattern, e.g., 'spiffe://example.org/service/*' (required if not using --file)")
+	cmd.Flags().StringVar(&permsStr, "permissions", "",
+		"Comma-separated permissions: read, write, list, super (required if not using --file)")
+	cmd.Flags().StringVar(&filePath, "file", "",
+		"Path to YAML file containing policy configuration")
+
+	return cmd
+}

--- a/app/spike/internal/cmd/policy/apply_test.go
+++ b/app/spike/internal/cmd/policy/apply_test.go
@@ -1,0 +1,332 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty_path",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "root_path_unchanged",
+			input:    "/",
+			expected: "/",
+		},
+		{
+			name:     "simple_path_no_trailing_slash",
+			input:    "secrets/database",
+			expected: "secrets/database",
+		},
+		{
+			name:     "simple_path_with_trailing_slash",
+			input:    "secrets/database/",
+			expected: "secrets/database",
+		},
+		{
+			name:     "complex_path_with_trailing_slash",
+			input:    "secrets/web-service/production/",
+			expected: "secrets/web-service/production",
+		},
+		{
+			name:     "complex_path_no_trailing_slash",
+			input:    "secrets/web-service/production",
+			expected: "secrets/web-service/production",
+		},
+		{
+			name:     "path_with_multiple_trailing_slashes",
+			input:    "secrets/database///",
+			expected: "secrets/database",
+		},
+		{
+			name:     "absolute_path_with_trailing_slash",
+			input:    "/secrets/database/",
+			expected: "/secrets/database",
+		},
+		{
+			name:     "absolute_path_no_trailing_slash",
+			input:    "/secrets/database",
+			expected: "/secrets/database",
+		},
+		{
+			name:     "single_segment_with_trailing_slash",
+			input:    "secrets/",
+			expected: "secrets",
+		},
+		{
+			name:     "wildcard_path_with_trailing_slash",
+			input:    "secrets/*/",
+			expected: "secrets/*",
+		},
+		{
+			name:     "deeply_nested_path",
+			input:    "secrets/app/env/production/database/primary/",
+			expected: "secrets/app/env/production/database/primary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizePath(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizePath(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestApplyPolicyFromFile(t *testing.T) {
+	// Create temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "spike-apply-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name         string
+		fileContent  string
+		fileName     string
+		expectedPath string
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name: "policy_with_trailing_slash_path",
+			fileContent: `name: test-policy
+spiffeid: spiffe://example.org/test/*
+path: secrets/database/production/
+permissions:
+  - read
+  - write`,
+			fileName:     "trailing-slash.yaml",
+			expectedPath: "secrets/database/production",
+			wantErr:      false,
+		},
+		{
+			name: "policy_with_normalized_path",
+			fileContent: `name: test-policy
+spiffeid: spiffe://example.org/test/*
+path: secrets/cache/redis
+permissions:
+  - read`,
+			fileName:     "normalized-path.yaml",
+			expectedPath: "secrets/cache/redis",
+			wantErr:      false,
+		},
+		{
+			name: "policy_with_root_path",
+			fileContent: `name: admin-policy
+spiffeid: spiffe://example.org/admin/*
+path: /
+permissions:
+  - super`,
+			fileName:     "root-path.yaml",
+			expectedPath: "/",
+			wantErr:      false,
+		},
+		{
+			name: "policy_with_empty_path",
+			fileContent: `name: invalid-policy
+spiffeid: spiffe://example.org/test/*
+path: ""
+permissions:
+  - read`,
+			fileName:    "empty-path.yaml",
+			wantErr:     true,
+			errContains: "path is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test file
+			filePath := filepath.Join(tempDir, tt.fileName)
+			err := os.WriteFile(filePath, []byte(tt.fileContent), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			// Test reading the policy
+			policy, err := readPolicyFromFile(filePath)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("readPolicyFromFile() expected error but got none")
+					return
+				}
+				if tt.errContains != "" {
+					// Check if error contains expected substring
+					found := false
+					if err != nil && len(err.Error()) > 0 {
+						errorStr := err.Error()
+						if len(errorStr) >= len(tt.errContains) {
+							for i := 0; i <= len(errorStr)-len(tt.errContains); i++ {
+								if errorStr[i:i+len(tt.errContains)] == tt.errContains {
+									found = true
+									break
+								}
+							}
+						}
+					}
+					if !found {
+						t.Errorf("readPolicyFromFile() expected error containing '%s', got '%v'", tt.errContains, err)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("readPolicyFromFile() unexpected error: %v", err)
+				return
+			}
+
+			// Test path normalization
+			normalizedPath := normalizePath(policy.Path)
+			if normalizedPath != tt.expectedPath {
+				t.Errorf("normalizePath(%q) = %q, want %q", policy.Path, normalizedPath, tt.expectedPath)
+			}
+		})
+	}
+}
+
+func TestApplyPolicyFromFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputName    string
+		inputSpiffed string
+		inputPath    string
+		inputPerms   string
+		expectedPath string
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name:         "flags_with_trailing_slash_path",
+			inputName:    "test-policy",
+			inputSpiffed: "spiffe://example.org/test/*",
+			inputPath:    "secrets/database/production/",
+			inputPerms:   "read,write",
+			expectedPath: "secrets/database/production",
+			wantErr:      false,
+		},
+		{
+			name:         "flags_with_normalized_path",
+			inputName:    "cache-policy",
+			inputSpiffed: "spiffe://example.org/cache/*",
+			inputPath:    "secrets/cache/redis",
+			inputPerms:   "read",
+			expectedPath: "secrets/cache/redis",
+			wantErr:      false,
+		},
+		{
+			name:         "flags_with_multiple_trailing_slashes",
+			inputName:    "multi-slash-policy",
+			inputSpiffed: "spiffe://example.org/test/*",
+			inputPath:    "secrets/test///",
+			inputPerms:   "read",
+			expectedPath: "secrets/test",
+			wantErr:      false,
+		},
+		{
+			name:         "flags_with_root_path",
+			inputName:    "root-policy",
+			inputSpiffed: "spiffe://example.org/admin/*",
+			inputPath:    "/",
+			inputPerms:   "super",
+			expectedPath: "/",
+			wantErr:      false,
+		},
+		{
+			name:         "missing_path_flag",
+			inputName:    "incomplete-policy",
+			inputSpiffed: "spiffe://example.org/test/*",
+			inputPath:    "",
+			inputPerms:   "read",
+			wantErr:      true,
+			errContains:  "--path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := getPolicyFromFlags(tt.inputName, tt.inputSpiffed, tt.inputPath, tt.inputPerms)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("getPolicyFromFlags() expected error but got none")
+					return
+				}
+				if tt.errContains != "" {
+					// Check if error contains expected substring
+					found := false
+					if err != nil && len(err.Error()) > 0 {
+						errorStr := err.Error()
+						if len(errorStr) >= len(tt.errContains) {
+							for i := 0; i <= len(errorStr)-len(tt.errContains); i++ {
+								if errorStr[i:i+len(tt.errContains)] == tt.errContains {
+									found = true
+									break
+								}
+							}
+						}
+					}
+					if !found {
+						t.Errorf("getPolicyFromFlags() expected error containing '%s', got '%v'", tt.errContains, err)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("getPolicyFromFlags() unexpected error: %v", err)
+				return
+			}
+
+			// Test path normalization
+			normalizedPath := normalizePath(policy.Path)
+			if normalizedPath != tt.expectedPath {
+				t.Errorf("normalizePath(%q) = %q, want %q", policy.Path, normalizedPath, tt.expectedPath)
+			}
+		})
+	}
+}
+
+func TestPathNormalizationIntegration(t *testing.T) {
+	// Test that various path formats all normalize correctly
+	pathTests := []struct {
+		original   string
+		normalized string
+	}{
+		{"secrets/database/password", "secrets/database/password"},
+		{"secrets/database/password/", "secrets/database/password"},
+		{"secrets/web-service/config/", "secrets/web-service/config"},
+		{"secrets/", "secrets"},
+		{"/secrets/", "/secrets"},
+		{"/", "/"},
+		{"app/env/production/db/", "app/env/production/db"},
+		{"cache/redis/session///", "cache/redis/session"},
+	}
+
+	for _, test := range pathTests {
+		t.Run("normalize_"+test.original, func(t *testing.T) {
+			result := normalizePath(test.original)
+			if result != test.normalized {
+				t.Errorf("normalizePath(%q) = %q, want %q", test.original, result, test.normalized)
+			}
+		})
+	}
+}

--- a/app/spike/internal/cmd/policy/create_test.go
+++ b/app/spike/internal/cmd/policy/create_test.go
@@ -1,0 +1,573 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+func TestReadPolicyFromFile(t *testing.T) {
+	// Create temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "spike-policy-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name        string
+		fileContent string
+		fileName    string
+		want        PolicySpec
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid_policy_file",
+			fileContent: `name: test-policy
+spiffeid: spiffe://example.org/test/*
+path: /secrets/*
+permissions:
+  - read
+  - write`,
+			fileName: "valid-policy.yaml",
+			want: PolicySpec{
+				Name:        "test-policy",
+				SpiffeID:    "spiffe://example.org/test/*",
+				Path:        "/secrets/*",
+				Permissions: []string{"read", "write"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid_policy_with_all_permissions",
+			fileContent: `name: full-access-policy
+spiffeid: spiffe://example.org/admin/*
+path: /*
+permissions:
+  - read
+  - write
+  - list
+  - super`,
+			fileName: "full-policy.yaml",
+			want: PolicySpec{
+				Name:        "full-access-policy",
+				SpiffeID:    "spiffe://example.org/admin/*",
+				Path:        "/*",
+				Permissions: []string{"read", "write", "list", "super"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing_name",
+			fileContent: `spiffeid: spiffe://example.org/test/*
+path: /secrets/*
+permissions:
+  - read`,
+			fileName:    "missing-name.yaml",
+			wantErr:     true,
+			errContains: "policy name is required",
+		},
+		{
+			name: "missing_spiffeid",
+			fileContent: `name: test-policy
+path: /secrets/*
+permissions:
+  - read`,
+			fileName:    "missing-spiffeid.yaml",
+			wantErr:     true,
+			errContains: "spiffeid is required",
+		},
+		{
+			name: "missing_path",
+			fileContent: `name: test-policy
+spiffeid: spiffe://example.org/test/*
+permissions:
+  - read`,
+			fileName:    "missing-path.yaml",
+			wantErr:     true,
+			errContains: "path is required",
+		},
+		{
+			name: "missing_permissions",
+			fileContent: `name: test-policy
+spiffeid: spiffe://example.org/test/*
+path: /secrets/*`,
+			fileName:    "missing-permissions.yaml",
+			wantErr:     true,
+			errContains: "permissions are required",
+		},
+		{
+			name: "empty_permissions_list",
+			fileContent: `name: test-policy
+spiffeid: spiffe://example.org/test/*
+path: /secrets/*
+permissions: []`,
+			fileName:    "empty-permissions.yaml",
+			wantErr:     true,
+			errContains: "permissions are required",
+		},
+		{
+			name: "invalid_yaml",
+			fileContent: `name: test-policy
+spiffeid: spiffe://example.org/test/*
+path: /secrets/*
+permissions: [
+  - read
+  - write`, // Invalid YAML - missing closing bracket
+			fileName:    "invalid-yaml.yaml",
+			wantErr:     true,
+			errContains: "failed to parse YAML file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test file
+			filePath := filepath.Join(tempDir, tt.fileName)
+			err := os.WriteFile(filePath, []byte(tt.fileContent), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			// Test the function
+			got, err := readPolicyFromFile(filePath)
+
+			// Check error expectations
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("readPolicyFromFile() expected error but got none")
+					return
+				}
+				if tt.errContains != "" && err.Error() == "" {
+					t.Errorf("readPolicyFromFile() expected error containing '%s', got empty error", tt.errContains)
+					return
+				}
+				if tt.errContains != "" {
+					// Check if error contains expected substring
+					found := false
+					if err != nil && len(err.Error()) > 0 {
+						errorStr := err.Error()
+						if len(errorStr) >= len(tt.errContains) {
+							for i := 0; i <= len(errorStr)-len(tt.errContains); i++ {
+								if errorStr[i:i+len(tt.errContains)] == tt.errContains {
+									found = true
+									break
+								}
+							}
+						}
+					}
+					if !found {
+						t.Errorf("readPolicyFromFile() expected error containing '%s', got '%v'", tt.errContains, err)
+					}
+				}
+				return
+			}
+
+			// Check success case
+			if err != nil {
+				t.Errorf("readPolicyFromFile() unexpected error: %v", err)
+				return
+			}
+
+			// Compare results
+			if got.Name != tt.want.Name {
+				t.Errorf("readPolicyFromFile() Name = %v, want %v", got.Name, tt.want.Name)
+			}
+			if got.SpiffeID != tt.want.SpiffeID {
+				t.Errorf("readPolicyFromFile() SpiffeID = %v, want %v", got.SpiffeID, tt.want.SpiffeID)
+			}
+			if got.Path != tt.want.Path {
+				t.Errorf("readPolicyFromFile() Path = %v, want %v", got.Path, tt.want.Path)
+			}
+			if len(got.Permissions) != len(tt.want.Permissions) {
+				t.Errorf("readPolicyFromFile() Permissions length = %v, want %v", len(got.Permissions), len(tt.want.Permissions))
+			} else {
+				for i, perm := range got.Permissions {
+					if perm != tt.want.Permissions[i] {
+						t.Errorf("readPolicyFromFile() Permissions[%d] = %v, want %v", i, perm, tt.want.Permissions[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestReadPolicyFromFileNotFound(t *testing.T) {
+	_, err := readPolicyFromFile("/nonexistent/file.yaml")
+	if err == nil {
+		t.Error("readPolicyFromFile() expected error for non-existent file but got none")
+	}
+	if err != nil && len(err.Error()) > 0 {
+		// Check if error contains "does not exist"
+		errorStr := err.Error()
+		expected := "does not exist"
+		found := false
+		if len(errorStr) >= len(expected) {
+			for i := 0; i <= len(errorStr)-len(expected); i++ {
+				if errorStr[i:i+len(expected)] == expected {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Errorf("readPolicyFromFile() expected error containing 'does not exist', got '%v'", err)
+		}
+	}
+}
+
+func TestGetPolicyFromFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputName     string
+		inputSpiffeID string
+		inputPath     string
+		inputPerms    string
+		want          PolicySpec
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name:          "valid_flags",
+			inputName:     "test-policy",
+			inputSpiffeID: "spiffe://example.org/test/*",
+			inputPath:     "/secrets/*",
+			inputPerms:    "read,write",
+			want: PolicySpec{
+				Name:        "test-policy",
+				SpiffeID:    "spiffe://example.org/test/*",
+				Path:        "/secrets/*",
+				Permissions: []string{"read", "write"},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "valid_flags_with_spaces",
+			inputName:     "test-policy",
+			inputSpiffeID: "spiffe://example.org/test/*",
+			inputPath:     "/secrets/*",
+			inputPerms:    "read, write, list",
+			want: PolicySpec{
+				Name:        "test-policy",
+				SpiffeID:    "spiffe://example.org/test/*",
+				Path:        "/secrets/*",
+				Permissions: []string{"read", "write", "list"},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "single_permission",
+			inputName:     "read-only-policy",
+			inputSpiffeID: "spiffe://example.org/readonly/*",
+			inputPath:     "/secrets/readonly/*",
+			inputPerms:    "read",
+			want: PolicySpec{
+				Name:        "read-only-policy",
+				SpiffeID:    "spiffe://example.org/readonly/*",
+				Path:        "/secrets/readonly/*",
+				Permissions: []string{"read"},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "all_permissions",
+			inputName:     "admin-policy",
+			inputSpiffeID: "spiffe://example.org/admin/*",
+			inputPath:     "/*",
+			inputPerms:    "read,write,list,super",
+			want: PolicySpec{
+				Name:        "admin-policy",
+				SpiffeID:    "spiffe://example.org/admin/*",
+				Path:        "/*",
+				Permissions: []string{"read", "write", "list", "super"},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "missing_name",
+			inputName:     "",
+			inputSpiffeID: "spiffe://example.org/test/*",
+			inputPath:     "/secrets/*",
+			inputPerms:    "read",
+			wantErr:       true,
+			errContains:   "--name",
+		},
+		{
+			name:          "missing_spiffeid",
+			inputName:     "test-policy",
+			inputSpiffeID: "",
+			inputPath:     "/secrets/*",
+			inputPerms:    "read",
+			wantErr:       true,
+			errContains:   "--spiffeid",
+		},
+		{
+			name:          "missing_path",
+			inputName:     "test-policy",
+			inputSpiffeID: "spiffe://example.org/test/*",
+			inputPath:     "",
+			inputPerms:    "read",
+			wantErr:       true,
+			errContains:   "--path",
+		},
+		{
+			name:          "missing_permissions",
+			inputName:     "test-policy",
+			inputSpiffeID: "spiffe://example.org/test/*",
+			inputPath:     "/secrets/*",
+			inputPerms:    "",
+			wantErr:       true,
+			errContains:   "--permissions",
+		},
+		{
+			name:          "multiple_missing_flags",
+			inputName:     "",
+			inputSpiffeID: "",
+			inputPath:     "/secrets/*",
+			inputPerms:    "read",
+			wantErr:       true,
+			errContains:   "required flags are missing",
+		},
+		{
+			name:          "empty_permissions_after_split",
+			inputName:     "test-policy",
+			inputSpiffeID: "spiffe://example.org/test/*",
+			inputPath:     "/secrets/*",
+			inputPerms:    ",,,",
+			want: PolicySpec{
+				Name:        "test-policy",
+				SpiffeID:    "spiffe://example.org/test/*",
+				Path:        "/secrets/*",
+				Permissions: []string{},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getPolicyFromFlags(tt.inputName, tt.inputSpiffeID, tt.inputPath, tt.inputPerms)
+
+			// Check error expectations
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("getPolicyFromFlags() expected error but got none")
+					return
+				}
+				if tt.errContains != "" {
+					// Check if error contains expected substring
+					found := false
+					if err != nil && len(err.Error()) > 0 {
+						errorStr := err.Error()
+						if len(errorStr) >= len(tt.errContains) {
+							for i := 0; i <= len(errorStr)-len(tt.errContains); i++ {
+								if errorStr[i:i+len(tt.errContains)] == tt.errContains {
+									found = true
+									break
+								}
+							}
+						}
+					}
+					if !found {
+						t.Errorf("getPolicyFromFlags() expected error containing '%s', got '%v'", tt.errContains, err)
+					}
+				}
+				return
+			}
+
+			// Check success case
+			if err != nil {
+				t.Errorf("getPolicyFromFlags() unexpected error: %v", err)
+				return
+			}
+
+			// Compare results
+			if got.Name != tt.want.Name {
+				t.Errorf("getPolicyFromFlags() Name = %v, want %v", got.Name, tt.want.Name)
+			}
+			if got.SpiffeID != tt.want.SpiffeID {
+				t.Errorf("getPolicyFromFlags() SpiffeID = %v, want %v", got.SpiffeID, tt.want.SpiffeID)
+			}
+			if got.Path != tt.want.Path {
+				t.Errorf("getPolicyFromFlags() Path = %v, want %v", got.Path, tt.want.Path)
+			}
+			if len(got.Permissions) != len(tt.want.Permissions) {
+				t.Errorf("getPolicyFromFlags() Permissions length = %v, want %v", len(got.Permissions), len(tt.want.Permissions))
+			} else {
+				for i, perm := range got.Permissions {
+					if perm != tt.want.Permissions[i] {
+						t.Errorf("getPolicyFromFlags() Permissions[%d] = %v, want %v", i, perm, tt.want.Permissions[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewPolicyCreateCommand(t *testing.T) {
+	source := &workloadapi.X509Source{}
+	spiffeId := "spiffe://example.org/spike"
+
+	cmd := newPolicyCreateCommand(source, spiffeId)
+
+	if cmd == nil {
+		t.Fatal("Expected command to be created, got nil")
+	}
+
+	if cmd.Use != "create" {
+		t.Errorf("Expected command use to be 'create', got '%s'", cmd.Use)
+	}
+
+	if cmd.Short != "Create a new policy" {
+		t.Errorf("Expected command short description to be 'Create a new policy', got '%s'", cmd.Short)
+	}
+
+	// Check if all required flags are present (create command only has flag-based input)
+	expectedFlags := []string{"name", "path", "spiffeid", "permissions"}
+	for _, flagName := range expectedFlags {
+		flag := cmd.Flags().Lookup(flagName)
+		if flag == nil {
+			t.Errorf("Expected flag '%s' to be present", flagName)
+		}
+	}
+}
+
+func TestPolicyCreateCommandFlagValidation(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		flags       map[string]string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "missing all flags",
+			flags:       map[string]string{},
+			expectError: true,
+			errorMsg:    "required flags are missing",
+		},
+		{
+			name: "missing name flag",
+			flags: map[string]string{
+				"path":        "secrets/database/production",
+				"spiffeid":    "spiffe://example.org/service/*",
+				"permissions": "read,write",
+			},
+			expectError: true,
+			errorMsg:    "required flags are missing: --name",
+		},
+		{
+			name: "missing path flag",
+			flags: map[string]string{
+				"name":        "test-policy",
+				"spiffeid":    "spiffe://example.org/service/*",
+				"permissions": "read,write",
+			},
+			expectError: true,
+			errorMsg:    "required flags are missing: --path",
+		},
+		{
+			name: "missing spiffeid flag",
+			flags: map[string]string{
+				"name":        "test-policy",
+				"path":        "secrets/database/production",
+				"permissions": "read,write",
+			},
+			expectError: true,
+			errorMsg:    "required flags are missing: --spiffeid",
+		},
+		{
+			name: "missing permissions flag",
+			flags: map[string]string{
+				"name":     "test-policy",
+				"path":     "secrets/database/production",
+				"spiffeid": "spiffe://example.org/service/*",
+			},
+			expectError: true,
+			errorMsg:    "required flags are missing: --permissions",
+		},
+		{
+			name: "all flags present",
+			flags: map[string]string{
+				"name":        "test-policy",
+				"path":        "secrets/database/production",
+				"spiffeid":    "spiffe://example.org/service/*",
+				"permissions": "read,write",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy, err := getPolicyFromFlags(
+				tt.flags["name"],
+				tt.flags["spiffeid"],
+				tt.flags["path"],
+				tt.flags["permissions"],
+			)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error message to contain '%s', got '%s'", tt.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %v", err)
+					return
+				}
+				if policy.Name != tt.flags["name"] {
+					t.Errorf("Expected policy name to be '%s', got '%s'", tt.flags["name"], policy.Name)
+				}
+				if policy.Path != tt.flags["path"] {
+					t.Errorf("Expected policy path to be '%s', got '%s'", tt.flags["path"], policy.Path)
+				}
+				if policy.SpiffeID != tt.flags["spiffeid"] {
+					t.Errorf("Expected policy spiffeid to be '%s', got '%s'", tt.flags["spiffeid"], policy.SpiffeID)
+				}
+			}
+		})
+	}
+}
+
+// TestPolicyCreateCommandFileInput removed - create command doesn't support file input
+// File input functionality is tested in apply_test.go for the apply command
+
+// TestPolicyCreateCommandFileInputErrors removed - create command doesn't support file input
+// File input error handling is tested in apply_test.go for the apply command
+
+// TestPolicyCreatePathNormalization removed - create command doesn't normalize paths
+// Path normalization is only used in the apply command and is tested in apply_test.go
+
+// Test that the create command is registered properly
+func TestPolicyCreateCommandRegistration(t *testing.T) {
+	source := &workloadapi.X509Source{}
+	spiffeId := "spiffe://example.org/spike"
+
+	policyCmd := NewPolicyCommand(source, spiffeId)
+
+	var createCmd *cobra.Command
+	for _, cmd := range policyCmd.Commands() {
+		if cmd.Use == "create" {
+			createCmd = cmd
+			break
+		}
+	}
+
+	if createCmd == nil {
+		t.Error("Expected 'create' command to be registered")
+	}
+}

--- a/app/spike/internal/cmd/policy/integration_test.go
+++ b/app/spike/internal/cmd/policy/integration_test.go
@@ -1,0 +1,232 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPolicySpecValidation tests the PolicySpec struct validation
+func TestPolicySpecValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy PolicySpec
+		valid  bool
+	}{
+		{
+			name: "valid_policy_spec",
+			policy: PolicySpec{
+				Name:        "test-policy",
+				SpiffeID:    "spiffe://example.org/test/*",
+				Path:        "/secrets/*",
+				Permissions: []string{"read", "write"},
+			},
+			valid: true,
+		},
+		{
+			name: "empty_name",
+			policy: PolicySpec{
+				Name:        "",
+				SpiffeID:    "spiffe://example.org/test/*",
+				Path:        "/secrets/*",
+				Permissions: []string{"read"},
+			},
+			valid: false,
+		},
+		{
+			name: "empty_spiffe_id",
+			policy: PolicySpec{
+				Name:        "test-policy",
+				SpiffeID:    "",
+				Path:        "/secrets/*",
+				Permissions: []string{"read"},
+			},
+			valid: false,
+		},
+		{
+			name: "empty_path",
+			policy: PolicySpec{
+				Name:        "test-policy",
+				SpiffeID:    "spiffe://example.org/test/*",
+				Path:        "",
+				Permissions: []string{"read"},
+			},
+			valid: false,
+		},
+		{
+			name: "empty_permissions",
+			policy: PolicySpec{
+				Name:        "test-policy",
+				SpiffeID:    "spiffe://example.org/test/*",
+				Path:        "/secrets/*",
+				Permissions: []string{},
+			},
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert permissions slice to comma-separated string
+			permsStr := ""
+			if len(tt.policy.Permissions) > 0 {
+				for i, perm := range tt.policy.Permissions {
+					if i > 0 {
+						permsStr += ","
+					}
+					permsStr += perm
+				}
+			}
+
+			// Test using readPolicyFromFile validation logic
+			// Create a temporary file with this policy
+			tempDir, err := os.MkdirTemp("", "spike-validation-test")
+			if err != nil {
+				t.Fatalf("Failed to create temp directory: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+
+			yamlContent := "name: " + tt.policy.Name + "\n"
+			yamlContent += "spiffeid: " + tt.policy.SpiffeID + "\n"
+			yamlContent += "path: " + tt.policy.Path + "\n"
+			yamlContent += "permissions:\n"
+			for _, perm := range tt.policy.Permissions {
+				yamlContent += "  - " + perm + "\n"
+			}
+
+			filePath := filepath.Join(tempDir, "test-policy.yaml")
+			err = os.WriteFile(filePath, []byte(yamlContent), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			_, err = readPolicyFromFile(filePath)
+			isValid := err == nil
+
+			if tt.valid && !isValid {
+				t.Errorf("Expected policy to be valid, but got error: %v", err)
+			}
+			if !tt.valid && isValid {
+				t.Errorf("Expected policy to be invalid, but it was accepted")
+			}
+		})
+	}
+}
+
+// TestYAMLParsingEdgeCases tests various YAML parsing edge cases
+func TestYAMLParsingEdgeCases(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "spike-yaml-edge-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name        string
+		yamlContent string
+		expectError bool
+		expectValue PolicySpec
+	}{
+		{
+			name: "quoted_values",
+			yamlContent: `name: "my-policy"
+spiffeid: "spiffe://example.org/quoted/*"
+path: "/secrets/quoted/*"
+permissions:
+  - "read"
+  - "write"`,
+			expectError: false,
+			expectValue: PolicySpec{
+				Name:        "my-policy",
+				SpiffeID:    "spiffe://example.org/quoted/*",
+				Path:        "/secrets/quoted/*",
+				Permissions: []string{"read", "write"},
+			},
+		},
+		{
+			name: "permissions_as_flow_sequence",
+			yamlContent: `name: flow-policy
+spiffeid: spiffe://example.org/flow/*
+path: /secrets/flow/*
+permissions: [read, write, list]`,
+			expectError: false,
+			expectValue: PolicySpec{
+				Name:        "flow-policy",
+				SpiffeID:    "spiffe://example.org/flow/*",
+				Path:        "/secrets/flow/*",
+				Permissions: []string{"read", "write", "list"},
+			},
+		},
+		{
+			name: "multiline_spiffe_id",
+			yamlContent: `name: multiline-policy
+spiffeid: >
+  spiffe://example.org/multiline/*
+path: /secrets/multiline/*
+permissions:
+  - read`,
+			expectError: false,
+			expectValue: PolicySpec{
+				Name:        "multiline-policy",
+				SpiffeID:    "spiffe://example.org/multiline/*\n",
+				Path:        "/secrets/multiline/*",
+				Permissions: []string{"read"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := filepath.Join(tempDir, tt.name+".yaml")
+			err := os.WriteFile(filePath, []byte(tt.yamlContent), 0644)
+			if err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			policy, err := readPolicyFromFile(filePath)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			// Trim any trailing whitespace from SpiffeID for comparison
+			if len(policy.SpiffeID) > 0 && policy.SpiffeID[len(policy.SpiffeID)-1] == '\n' {
+				policy.SpiffeID = policy.SpiffeID[:len(policy.SpiffeID)-1]
+			}
+			if len(tt.expectValue.SpiffeID) > 0 && tt.expectValue.SpiffeID[len(tt.expectValue.SpiffeID)-1] == '\n' {
+				tt.expectValue.SpiffeID = tt.expectValue.SpiffeID[:len(tt.expectValue.SpiffeID)-1]
+			}
+
+			if policy.Name != tt.expectValue.Name {
+				t.Errorf("Name = %v, want %v", policy.Name, tt.expectValue.Name)
+			}
+			if policy.SpiffeID != tt.expectValue.SpiffeID {
+				t.Errorf("SpiffeID = %v, want %v", policy.SpiffeID, tt.expectValue.SpiffeID)
+			}
+			if policy.Path != tt.expectValue.Path {
+				t.Errorf("Path = %v, want %v", policy.Path, tt.expectValue.Path)
+			}
+			if len(policy.Permissions) != len(tt.expectValue.Permissions) {
+				t.Errorf("Permissions length = %d, want %d", len(policy.Permissions), len(tt.expectValue.Permissions))
+			} else {
+				for i, perm := range policy.Permissions {
+					if perm != tt.expectValue.Permissions[i] {
+						t.Errorf("Permissions[%d] = %v, want %v", i, perm, tt.expectValue.Permissions[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/app/spike/internal/cmd/policy/new.go
+++ b/app/spike/internal/cmd/policy/new.go
@@ -37,10 +37,10 @@ import (
 // Each subcommand has its own set of flags and arguments. See the individual
 // command documentation for details.
 func NewPolicyCommand(source *workloadapi.X509Source, spiffeId string) *cobra.Command {
-    cmd := &cobra.Command{
-        Use:   "policy",
-        Short: "Manage policies",
-        Long: `Manage access control policies.
+	cmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Manage policies",
+		Long: `Manage access control policies.
 
 		Policies control which workloads can access which secrets.
 		Each policy defines a set of permissions granted to workloads
@@ -51,13 +51,14 @@ func NewPolicyCommand(source *workloadapi.X509Source, spiffeId string) *cobra.Co
 		list      List all policies
 		get       Get details of a specific policy
 		delete    Delete a policy`,
-    }
+	}
 
-    // Add subcommands
-    cmd.AddCommand(newPolicyListCommand(source, spiffeId))
-    cmd.AddCommand(newPolicyGetCommand(source, spiffeId))
-    cmd.AddCommand(newPolicyCreateCommand(source, spiffeId))
-    cmd.AddCommand(newPolicyDeleteCommand(source, spiffeId))
+	// Add subcommands
+	cmd.AddCommand(newPolicyListCommand(source, spiffeId))
+	cmd.AddCommand(newPolicyGetCommand(source, spiffeId))
+	cmd.AddCommand(newPolicyCreateCommand(source, spiffeId))
+	cmd.AddCommand(newPolicyDeleteCommand(source, spiffeId))
+	cmd.AddCommand(newPolicyApplyCommand(source, spiffeId))
 
-    return cmd
+	return cmd
 }

--- a/app/spike/internal/cmd/policy/types.go
+++ b/app/spike/internal/cmd/policy/types.go
@@ -1,0 +1,110 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE.
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PolicySpec represents the YAML structure for policy configuration
+type PolicySpec struct {
+	Name        string   `yaml:"name"`
+	SpiffeID    string   `yaml:"spiffeid"`
+	Path        string   `yaml:"path"`
+	Permissions []string `yaml:"permissions"`
+}
+
+// readPolicyFromFile reads a policy configuration from a YAML file
+func readPolicyFromFile(filePath string) (PolicySpec, error) {
+	var policy PolicySpec
+
+	// Check if file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return policy, fmt.Errorf("file %s does not exist", filePath)
+	}
+
+	// Read file content
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return policy, fmt.Errorf("failed to read file %s: %v", filePath, err)
+	}
+
+	// Parse YAML
+	err = yaml.Unmarshal(data, &policy)
+	if err != nil {
+		return policy, fmt.Errorf("failed to parse YAML file %s: %v", filePath, err)
+	}
+
+	// Validate required fields
+	if policy.Name == "" {
+		return policy, fmt.Errorf("policy name is required in YAML file")
+	}
+	if policy.SpiffeID == "" {
+		return policy, fmt.Errorf("spiffeid is required in YAML file")
+	}
+	if policy.Path == "" {
+		return policy, fmt.Errorf("path is required in YAML file")
+	}
+	if len(policy.Permissions) == 0 {
+		return policy, fmt.Errorf("permissions are required in YAML file")
+	}
+
+	return policy, nil
+}
+
+// getPolicyFromFlags extracts policy configuration from command line flags
+func getPolicyFromFlags(name, spiffeIdPattern, pathPattern, permsStr string) (PolicySpec, error) {
+	var policy PolicySpec
+
+	// Check if all required flags are provided
+	var missingFlags []string
+	if name == "" {
+		missingFlags = append(missingFlags, "name")
+	}
+	if pathPattern == "" {
+		missingFlags = append(missingFlags, "path")
+	}
+	if spiffeIdPattern == "" {
+		missingFlags = append(missingFlags, "spiffeid")
+	}
+	if permsStr == "" {
+		missingFlags = append(missingFlags, "permissions")
+	}
+
+	if len(missingFlags) > 0 {
+		flagList := ""
+		for i, flag := range missingFlags {
+			if i > 0 {
+				flagList += ", "
+			}
+			flagList += "--" + flag
+		}
+		return policy, fmt.Errorf("required flags are missing: %s (or use --file to read from YAML)", flagList)
+	}
+
+	// Convert comma-separated permissions to slice
+	var permissions []string
+	if permsStr != "" {
+		for _, perm := range strings.Split(permsStr, ",") {
+			perm = strings.TrimSpace(perm)
+			if perm != "" {
+				permissions = append(permissions, perm)
+			}
+		}
+	}
+
+	policy = PolicySpec{
+		Name:        name,
+		SpiffeID:    spiffeIdPattern,
+		Path:        pathPattern,
+		Permissions: permissions,
+	}
+
+	return policy, nil
+}

--- a/examples/README-policy-yaml.md
+++ b/examples/README-policy-yaml.md
@@ -1,0 +1,292 @@
+# SPIKE Policy Configuration
+
+This document describes the policy management commands in SPIKE, including YAML file support and command differences.
+
+## Overview
+
+SPIKE provides two commands for managing policies:
+
+1. **`spike policy create`** - Traditional command-line interface (backward compatibility)
+2. **`spike policy apply`** - Enhanced command with YAML file support (recommended for new workflows)
+
+Both commands use **upsert semantics** - they will create a new policy if one doesn't exist, or update an existing policy if one with the same name already exists. This makes them safe to use in automation and GitOps workflows.
+
+## Commands
+
+### spike policy create
+
+Traditional command-line interface for policy creation:
+
+```bash
+spike policy create \
+    --name "web-service-policy" \
+    --spiffeid "spiffe://example.org/web-service/*" \
+    --path "secrets/web-service/database" \
+    --permissions "read,write"
+```
+
+**Features:**
+- Command-line flags only
+- Upsert semantics (create or update)
+- Backward compatibility with existing scripts
+
+### spike policy apply (Recommended)
+
+Enhanced command with YAML file support:
+
+```bash
+# Using command-line flags
+spike policy apply \
+    --name "web-service-policy" \
+    --spiffeid "spiffe://example.org/web-service/*" \
+    --path "secrets/web-service/database" \
+    --permissions "read,write"
+
+# Using YAML file (recommended)
+spike policy apply --file policy.yaml
+```
+
+**Features:**
+- YAML file support for GitOps workflows
+- Command-line flags (same as create)
+- Path normalization (removes trailing slashes)
+- Upsert semantics (create or update)
+- Better suited for version control
+
+## YAML File Format
+
+### Basic Structure
+```yaml
+# Policy name - must be unique within the system
+name: "web-service-policy"
+
+# SPIFFE ID pattern for workload matching
+spiffeid: "spiffe://example.org/web-service/*"
+
+# Path pattern for access control
+# Note: Trailing slashes are automatically removed during normalization
+path: "secrets/web-service/database"
+
+# List of permissions to grant
+permissions:
+  - read
+  - write
+```
+
+### Path Normalization
+
+The `apply` command automatically normalizes paths by removing trailing slashes:
+
+```yaml
+# These paths are all normalized to the same value:
+path: "secrets/database/production"    # ✓ Normalized form
+path: "secrets/database/production/"   # → "secrets/database/production"
+path: "secrets/database/production//"  # → "secrets/database/production"
+
+# Special case: root path is preserved
+path: "/"  # ✓ Remains as "/"
+```
+
+### Realistic Path Examples
+
+```yaml
+# Database secrets
+name: "database-policy"
+spiffeid: "spiffe://example.org/database/*"
+path: "secrets/database/production"
+permissions: [read]
+
+# Web service configuration
+name: "web-service-policy"
+spiffeid: "spiffe://example.org/web-service/*"
+path: "secrets/web-service/config"
+permissions: [read, write]
+
+# Cache credentials
+name: "cache-policy"
+spiffeid: "spiffe://example.org/cache/*"
+path: "secrets/cache/redis/session"
+permissions: [read]
+
+# Application environment variables
+name: "app-env-policy"
+spiffeid: "spiffe://example.org/app/*"
+path: "secrets/app/env/production"
+permissions: [read, list]
+```
+
+### All Available Permissions
+```yaml
+name: "admin-policy"
+spiffeid: "spiffe://example.org/admin/*"
+path: "secrets"
+permissions:
+  - read    # Permission to read secrets
+  - write   # Permission to create, update, or delete secrets
+  - list    # Permission to list resources
+  - super   # Administrative permissions
+```
+
+### Alternative YAML Formats
+
+#### Flow Sequence for Permissions
+```yaml
+name: "database-policy"
+spiffeid: "spiffe://example.org/database/*"
+path: "secrets/database/production"
+permissions: [read, write, list]
+```
+
+#### Quoted Values
+```yaml
+name: "cache-policy"
+spiffeid: "spiffe://example.org/cache/*"
+path: "secrets/cache/redis"
+permissions:
+  - "read"
+  - "write"
+```
+
+## Example Files
+
+The following example files are provided:
+
+- `examples/policy-example.yaml` - Basic policy example
+- `examples/test-policies/basic-policy.yaml` - Minimal policy
+- `examples/test-policies/admin-policy.yaml` - Full permissions policy
+- `examples/test-policies/invalid-permissions.yaml` - Example with invalid permissions (for testing)
+
+## Validation
+
+All policy configurations are validated to ensure:
+
+1. **Required fields**: `name`, `spiffeid`, `path`, and `permissions` must be present
+2. **Valid permissions**: Only `read`, `write`, `list`, and `super` are allowed
+3. **Valid YAML syntax**: Proper YAML formatting is required (for YAML files)
+4. **Non-empty values**: All fields must have non-empty values
+
+## Testing
+
+### Running Tests
+
+To run all policy-related tests:
+```bash
+go test ./app/spike/internal/cmd/policy -v
+```
+
+To run specific test suites:
+```bash
+# Test YAML file reading functionality
+go test ./app/spike/internal/cmd/policy -v -run TestReadPolicyFromFile
+
+# Test command-line flag parsing
+go test ./app/spike/internal/cmd/policy -v -run TestGetPolicyFromFlags
+
+# Test policy validation logic
+go test ./app/spike/internal/cmd/policy -v -run TestPolicySpecValidation
+
+# Test YAML parsing edge cases
+go test ./app/spike/internal/cmd/policy -v -run TestYAMLParsingEdgeCases
+
+# Test path normalization functionality
+go test ./app/spike/internal/cmd/policy -v -run TestNormalizePath
+
+# Test apply command functionality
+go test ./app/spike/internal/cmd/policy -v -run TestApply
+```
+
+### Test Coverage
+
+The test suite covers:
+
+1. **Valid configurations**
+   - Basic policy configuration
+   - All permission types
+   - Different YAML formats (flow sequences, quoted values)
+   - Path normalization scenarios
+
+2. **Invalid configurations**
+   - Missing required fields (`name`, `spiffeid`, `path`, `permissions`)
+   - Empty permission lists
+   - Invalid YAML syntax
+   - Non-existent files
+
+3. **Command-line flag validation**
+   - Valid flag combinations
+   - Missing required flags
+   - Permission parsing with spaces
+   - Empty permission strings
+
+4. **Path normalization**
+   - Trailing slash removal
+   - Multiple trailing slashes
+   - Root path preservation
+   - Empty path handling
+
+5. **Edge cases**
+   - Multiline YAML values
+   - Quoted and unquoted strings
+   - Different permission list formats
+   - File system errors
+
+## Error Handling
+
+The implementation provides clear error messages for common issues:
+
+- **File not found**: `file policy.yaml does not exist`
+- **Invalid YAML**: `failed to parse YAML file policy.yaml: yaml: line 5: found character that cannot start any token`
+- **Missing fields**: `policy name is required in YAML file`
+- **Invalid permissions**: `invalid permission 'invalid_permission'. Valid permissions are: read, write, list, super`
+- **Missing flags**: `required flags are missing: --name, --path (or use --file to read from YAML)`
+
+## GitOps Integration
+
+YAML files can be easily integrated into GitOps workflows:
+
+1. **Store policy YAML files in a Git repository**
+   ```bash
+   policies/
+   ├── web-service-policy.yaml
+   ├── database-policy.yaml
+   └── admin-policy.yaml
+   ```
+
+2. **Use CI/CD pipelines to validate policies before deployment**
+   ```bash
+   # Validation step in CI
+   for policy in policies/*.yaml; do
+     spike policy apply --file "$policy" --dry-run
+   done
+   ```
+
+3. **Apply policies using `spike policy apply --file` in deployment scripts**
+   ```bash
+   # Deployment script
+   for policy in policies/*.yaml; do
+     spike policy apply --file "$policy"
+   done
+   ```
+
+4. **Version control changes to policies alongside application code**
+5. **Use upsert semantics to safely apply policy changes without worrying about conflicts**
+
+## Migration from API-style Paths
+
+If you have existing policies with API-style paths, consider updating them to use more descriptive paths:
+
+```yaml
+# Old API-style paths
+path: "/api/v1/secrets/*"
+path: "/api/v1/database/*"
+
+# New descriptive paths (recommended)
+path: "secrets/database/production"
+path: "secrets/web-service/config"
+path: "secrets/cache/redis/session"
+```
+
+The new path format is:
+- More readable and self-documenting
+- Better suited for secret management workflows
+- Consistent with modern secret management practices
+- Automatically normalized (trailing slashes removed) 

--- a/examples/policy-example.yaml
+++ b/examples/policy-example.yaml
@@ -1,0 +1,19 @@
+# Example policy configuration for spike policy apply --file
+# This demonstrates how to define a policy using YAML instead of command line flags
+
+# Policy name - must be unique within the system
+name: "web-service-policy"
+
+# SPIFFE ID pattern for workload matching
+# This pattern determines which workloads this policy applies to
+spiffeid: "spiffe://example.org/web-service/*"
+
+# Path pattern for access control
+# This pattern determines which resources this policy grants access to
+path: "secrets/web-service/database"
+
+# List of permissions to grant
+# Valid values: read, write, list, super
+permissions:
+  - read
+  - write 

--- a/examples/test-policies/admin-policy.yaml
+++ b/examples/test-policies/admin-policy.yaml
@@ -1,0 +1,9 @@
+# Admin policy configuration with all permissions
+name: "admin-policy"
+spiffeid: "spiffe://example.org/admin/*"
+path: "secrets"
+permissions:
+  - read
+  - write
+  - list
+  - super 

--- a/examples/test-policies/basic-policy.yaml
+++ b/examples/test-policies/basic-policy.yaml
@@ -1,0 +1,6 @@
+# Basic policy configuration for testing
+name: "basic-test-policy"
+spiffeid: "spiffe://example.org/basic/*"
+path: "secrets/basic/config"
+permissions:
+  - read 

--- a/examples/test-policies/invalid-permissions.yaml
+++ b/examples/test-policies/invalid-permissions.yaml
@@ -1,0 +1,8 @@
+# Policy with invalid permissions - should be rejected by validation
+name: "invalid-perms-policy"
+spiffeid: "spiffe://example.org/test/*"
+path: "secrets/test/config"
+permissions:
+  - read
+  - invalid_permission
+  - write 


### PR DESCRIPTION
Policy has been created by parameters in the cli command. Instead of parameters in the cli ,  yaml file can be used too

Signed-off-by: Murat Parlakisik parlakisik@gmail.com

Fixes: #140 