### PR TITLE
feat(lock): add lock/unlock commands 

### DIFF
--- a/app/spike/internal/cmd/operator/lock.go
+++ b/app/spike/internal/cmd/operator/lock.go
@@ -1,0 +1,66 @@
+package operator
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spiffe/spike/internal/lock"
+
+	"os"
+
+	"github.com/spiffe/spike/app/spike/internal/env"
+
+	"github.com/spiffe/spike-sdk-go/spiffeid"
+
+	"github.com/spiffe/spike/app/spike/internal/trust"
+)
+
+// newOperatorLockCommand creates a new cobra command for locking
+// SPIKE Nexus, disabling all operations until it is explicitly unlocked.
+//
+// This command can only be used by operators with the `watchdog` role.
+//
+// Parameters:
+//   - source *workloadapi.X509Source: The X.509 source for SPIFFE authentication.
+//   - spiffeId string: The SPIFFE ID of the caller for role-based access control.
+//
+// Returns:
+//   - *cobra.Command: A cobra command that implements the lock functionality.
+//
+// The command performs the following operations:
+//   - Verifies the caller has the 'lock' (watchdog) role, aborting otherwise.
+//   - Authenticates the lock request.
+//   - Sends the lock request to the SPIKE API.
+//   - Prints confirmation if successful.
+func newOperatorLockCommand(spiffeId string,
+) *cobra.Command {
+	return &cobra.Command{
+		Use:   "lock",
+		Short: "Lock SPIKE Nexus and disable all operations",
+		Run: func(cmd *cobra.Command, args []string) {
+			if !spiffeid.IsPilotLock(env.TrustRoot(), spiffeId) {
+				fmt.Println("")
+				fmt.Println("  You need to have a `lock` role to use this command.")
+				fmt.Println("  Please run ./hack/bare-metal/entry/spire-server-entry-lock-unlock-register.sh")
+				fmt.Println("  with necessary privileges to assign this role.")
+				fmt.Println("")
+				os.Exit(1)
+			}
+
+			trust.AuthenticateLock(spiffeId)
+
+			if lock.IsLocked() {
+				fmt.Println("SPIKE is already locked. No action taken.")
+				return
+			}
+
+			if err := lock.Lock(); err != nil {
+				fmt.Println("  Failed to lock SPIKE:", err)
+				os.Exit(1)
+			}
+
+			fmt.Println("SPIKE has been locked. All operations are now disabled.")
+			fmt.Println("To unlock SPIKE, run `spike operator unlock`.")
+		},
+	}
+}

--- a/app/spike/internal/cmd/operator/new.go
+++ b/app/spike/internal/cmd/operator/new.go
@@ -29,6 +29,8 @@ func NewOperatorCommand(
 
 	cmd.AddCommand(newOperatorRecoverCommand(source, spiffeId))
 	cmd.AddCommand(newOperatorRestoreCommand(source, spiffeId))
+	cmd.AddCommand(newOperatorLockCommand(spiffeId))
+cmd.AddCommand(newOperatorUnlockCommand(spiffeId))
 
 	return cmd
 }

--- a/app/spike/internal/cmd/operator/new.go
+++ b/app/spike/internal/cmd/operator/new.go
@@ -5,8 +5,10 @@
 package operator
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"github.com/spiffe/spike/internal/lock"
 )
 
 // NewOperatorCommand creates a new cobra.Command for managing SPIKE admin
@@ -25,6 +27,12 @@ func NewOperatorCommand(
 	cmd := &cobra.Command{
 		Use:   "operator",
 		Short: "Manage admin operations",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+        if lock.IsLocked() { 
+            return fmt.Errorf("SPIKE is locked — please unlock before running this command")
+        }
+        return nil
+    },
 	}
 
 	cmd.AddCommand(newOperatorRecoverCommand(source, spiffeId))

--- a/app/spike/internal/cmd/operator/unlock.go
+++ b/app/spike/internal/cmd/operator/unlock.go
@@ -1,0 +1,66 @@
+package operator
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spiffe/spike/internal/lock"
+
+	"os"
+
+	"github.com/spiffe/spike/app/spike/internal/env"
+
+	"github.com/spiffe/spike-sdk-go/spiffeid"
+
+	"github.com/spiffe/spike/app/spike/internal/trust"
+)
+
+// newOperatorLockCommand creates a new cobra command for locking
+// SPIKE Nexus, disabling all operations until it is explicitly unlocked.
+//
+// This command can only be used by operators with the `watchdog` role.
+//
+// Parameters:
+//   - source *workloadapi.X509Source: The X.509 source for SPIFFE authentication.
+//   - spiffeId string: The SPIFFE ID of the caller for role-based access control.
+//
+// Returns:
+//   - *cobra.Command: A cobra command that implements the lock functionality.
+//
+// The command performs the following operations:
+//   - Verifies the caller has the 'lock' (watchdog) role, aborting otherwise.
+//   - Authenticates the lock request.
+//   - Sends the lock request to the SPIKE API.
+//   - Prints confirmation if successful.
+func newOperatorUnlockCommand(spiffeId string,
+) *cobra.Command {
+	return &cobra.Command{
+		Use:   "unlock",
+		Short: "Unlock SPIKE Nexus and re-enable operations",
+		Run: func(cmd *cobra.Command, args []string) {
+			if !spiffeid.IsPilotLock(env.TrustRoot(), spiffeId) {
+				fmt.Println("")
+				fmt.Println("  You need to have a `unlock` role to use this command.")
+				fmt.Println("  Please run ./hack/bare-metal/entry/spire-server-entry-lock-unlock-register.sh")
+				fmt.Println("  with necessary privileges to assign this role.")
+				fmt.Println("")
+				os.Exit(1)
+			}
+
+			trust.AuthenticateLock(spiffeId)
+
+			if lock.IsLocked() {
+				fmt.Println("SPIKE is already locked. No action taken.")
+				return
+			}
+
+			if err := lock.Lock(); err != nil {
+				fmt.Println("  Failed to lock SPIKE:", err)
+				os.Exit(1)
+			}
+
+			fmt.Println("SPIKE has been locked. All operations are now disabled.")
+			fmt.Println("To unlock SPIKE, run `spike operator unlock`.")
+		},
+	}
+}

--- a/app/spike/internal/cmd/secret/new.go
+++ b/app/spike/internal/cmd/secret/new.go
@@ -5,8 +5,10 @@
 package secret
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"github.com/spiffe/spike/internal/lock"
 )
 
 // NewSecretCommand creates a new Cobra command for managing secrets.
@@ -18,6 +20,12 @@ func NewSecretCommand(
 	cmd := &cobra.Command{
 		Use:   "secret",
 		Short: "Manage secrets",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+        if lock.IsLocked() { 
+            return fmt.Errorf("SPIKE is locked — please unlock before running this command")
+        }
+        return nil
+    },
 	}
 
 	// Add subcommands to the policy command

--- a/app/spike/internal/trust/spiffeid.go
+++ b/app/spike/internal/trust/spiffeid.go
@@ -56,3 +56,17 @@ func AuthenticateRestore(spiffeid string) {
 		)
 	}
 }
+
+// AuthenticateLock verifies if the given SPIFFE ID is valid for locking.
+// Logs a fatal error and exits if the SPIFFE ID validation fails.
+func AuthenticateLock(spiffeid string) {
+	if !svid.IsPilotLock(env.TrustRoot(), spiffeid) {
+		log.Log().Error(
+			"AuthenticateLock: You need a 'lock/unlock' SPIFFE ID to use this command.",
+		)
+		log.FatalF(
+			"AuthenticateLock: You are not authorized to use this command (%s).\n",
+			spiffeid,
+		)
+	}
+}

--- a/hack/bare-metal/entry/spire-server-entry-lock-unlock-register.sh
+++ b/hack/bare-metal/entry/spire-server-entry-lock-unlock-register.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+#  \\\\\ Copyright 2024-present SPIKE contributors.
+# \\\\\\\ SPDX-License-Identifier: Apache-2.0
+
+# Set path to the SPIKE binary
+PILOT_PATH="$(pwd)/spike"
+PILOT_SHA=$(sha256sum "$PILOT_PATH" | cut -d' ' -f1)
+
+# Register a new SPIFFE ID for lock/unlock
+spire-server entry create \
+  -spiffeID "spiffe://spike.ist/spike/pilot/role/watchdog" \
+  -parentID "spiffe://spike.ist/spire-agent" \
+  -selector "unix:uid:$(id -u)" \
+  -selector "unix:path:$PILOT_PATH" \
+  -selector "unix:sha256:$PILOT_SHA" \
+  -ttl 3600
+
+# Wait for propagation
+echo "Waiting for SPIFFE entry to propagate..."
+sleep 5
+echo "Watchdog SPIFFE ID registered successfully!"

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,37 @@
+//    \\ SPIKE: Secure your secrets with SPIFFE. — https://spike.ist/
+//  \\\\\ Copyright 2024-present SPIKE contributors.
+// \\\\\\\ SPDX-License-Identifier: Apache-2.0
+package lock
+
+import (
+    "os"
+    "sync/atomic"
+)
+
+var locked atomic.Bool
+
+const lockFile = "/var/lib/spike/locked" 
+
+// LockFile is the file used to indicate that SPIKE is locked.
+func init() {
+    if _, err := os.Stat(lockFile); err == nil {
+        locked.Store(true)
+    }
+}
+
+// Lock sets the SPIKE lock by creating a lock file and marking it as locked.
+func Lock() error {
+    locked.Store(true)
+    return os.WriteFile(lockFile, []byte("locked"), 0600)
+}
+
+// Unlock clears the SPIKE lock by removing the lock file.
+func Unlock() error {
+    locked.Store(false)
+    return os.Remove(lockFile)
+}
+
+// IsLocked checks if SPIKE is currently locked.
+func IsLocked() bool {
+    return locked.Load()
+}


### PR DESCRIPTION

This PR implements the lock/unlock functionality for SPIKE Nexus with the following changes:

- Added new lock and unlock CLI commands under the operator command, allowing authorized operators to lock and unlock SPIKE Nexus.

- Introduced a file-based locking mechanism (/var/lib/spike/locked) to persist lock state across restarts.

- Enforced lock condition globally in operator and secret commands, preventing execution while SPIKE Nexus is locked.

- Added AuthenticateLock function to validate SPIFFE IDs for lock/unlock commands, requiring the lock(watchdog) role.

- Created a shell script (spire-server-entry-lock-unlock-register.sh) to register the required SPIFFE ID with appropriate selectors.

- Updated SPIFFE ID validation helpers to support lock/unlock authorization checks.

This PR fixes issue #185.

Note: This is not the final version. Some build bugs were encountered, so this PR is opened as a draft for now.