### PR TITLE
feat(policy): Add filtering to policy list command

### DIFF
--- a/app/spike/internal/cmd/policy/filter.go
+++ b/app/spike/internal/cmd/policy/filter.go
@@ -25,7 +25,7 @@ import (
 //   - string: The policy ID if found
 //   - error: An error if the policy is not found or there's an API issue
 func findPolicyByName(api *spike.Api, name string) (string, error) {
-	policies, err := api.ListPolicies()
+	policies, err := api.ListPolicies("", "")
 	if err != nil {
 		return "", err
 	}

--- a/app/spike/internal/cmd/policy/validation.go
+++ b/app/spike/internal/cmd/policy/validation.go
@@ -69,7 +69,7 @@ func validatePermissions(permsStr string) ([]data.PolicyPermission, error) {
 //   - bool: true if a policy with the name exists, false otherwise
 //   - error: An error if there's an issue with the API call
 func checkPolicyNameExists(api *spike.Api, name string) (bool, error) {
-	policies, err := api.ListPolicies()
+	policies, err := api.ListPolicies("", "")
 	if err != nil {
 		return false, err
 	}

--- a/docs-src/content/getting-started/commands/policy.md
+++ b/docs-src/content/getting-started/commands/policy.md
@@ -81,11 +81,12 @@ When a workload attempts to access a resource in SPIKE:
 ### `spike policy list`
 
 ```bash
-spike policy list [--format=human|json]
+spike policy list [--format=human|json] [--path=<pattern> | --spiffeid=<pattern>]
 ```
 
-Lists all policies in the system. Use `--format=json` for 
-machine-readable output.
+Lists all policies in the system. Can be filtered by a resource path pattern or a SPIFFE ID pattern.
+
+**Note:** `--path` and `--spiffeid` flags cannot be used together.
 
 ### `spike policy create`
 

--- a/docs-src/content/operations/release.md
+++ b/docs-src/content/operations/release.md
@@ -154,7 +154,7 @@ spike policy create --name=workload-can-read \
 ### Verify the Policy Creation
 
 ```bash
-spike policy list
+spike policy list --format=json
 
 # Sample output:
 # [


### PR DESCRIPTION
This change introduces the ability to filter policies in the
`spike policy list` command by either a path pattern or a
SPIFFE ID pattern.

- Added `--path` and `--spiffeid` flags to `spike policy list`.
- These two filtering options are mutually exclusive and cannot be used together.
- The backend (Nexus API) has been updated to support these filter parameters.
- The command documentation has been updated to include the new flags and usage examples.