### PR TITLE
remove path normalization.

### DIFF
--- a/app/nexus/internal/state/base/path_test.go
+++ b/app/nexus/internal/state/base/path_test.go
@@ -220,7 +220,7 @@ func TestListKeys_SpecialCharacters(t *testing.T) {
 				}
 			}
 			if !found {
-				t.Errorf("Expected path %s not found in result", expectedPath)
+				t.Errorf("Expected pathPattern %s not found in result", expectedPath)
 			}
 		}
 	})
@@ -327,7 +327,7 @@ func TestListKeys_DuplicatePaths(t *testing.T) {
 		}
 
 		if actualCount != expectedCount {
-			t.Errorf("Expected path %s to appear %d time(s), got %d", path, expectedCount, actualCount)
+			t.Errorf("Expected pathPattern %s to appear %d time(s), got %d", path, expectedCount, actualCount)
 		}
 	})
 }

--- a/app/nexus/internal/state/base/policy.go
+++ b/app/nexus/internal/state/base/policy.go
@@ -27,14 +27,14 @@ var (
 )
 
 // CheckAccess determines if a given SPIFFE ID has the required permissions for
-// a specific path. It first checks if the ID belongs to SPIKE Pilot (which has
+// a specific pathPattern. It first checks if the ID belongs to SPIKE Pilot (which has
 // unrestricted access), then evaluates against all defined policies. Policies
 // are checked in order, with wildcard patterns evaluated first, followed by
 // specific pattern matching using regular expressions.
 //
 // Parameters:
 //   - spiffeId: The SPIFFE ID of the requestor
-//   - path: The resource path being accessed
+//   - pathPattern: The resource pathPattern being accessed
 //   - wants: Slice of permissions being requested
 //
 // Returns:
@@ -46,9 +46,9 @@ var (
 //  3. A matching policy contains all requested permissions
 //
 // A policy matches when:
-//  1. It has wildcard patterns ("*") for both SPIFFE ID and path, or
-//  2. Its SPIFFE ID pattern matches the requestor's ID, and its path pattern
-//     matches the requested path
+//  1. It has wildcard patterns ("*") for both SPIFFE ID and pathPattern, or
+//  2. Its SPIFFE ID pattern matches the requestor's ID, and its pathPattern pattern
+//     matches the requested pathPattern
 func CheckAccess(
 	peerSPIFFEID string, path string, wants []data.PolicyPermission,
 ) bool {
@@ -160,7 +160,7 @@ func CreatePolicy(policy data.Policy) (data.Policy, error) {
 			return data.Policy{},
 				errors.Join(
 					ErrInvalidPolicy,
-					fmt.Errorf("%s: %v", "invalid path pattern", err),
+					fmt.Errorf("%s: %v", "invalid pathPattern pattern", err),
 				)
 		}
 		policy.PathRegex = pathRegex
@@ -263,12 +263,12 @@ func ListPolicies() ([]data.Policy, error) {
 	return result, nil
 }
 
-// ListPoliciesByPath returns all policies that match a specific path pattern.
+// ListPoliciesByPath returns all policies that match a specific pathPattern pattern.
 // It filters the policy store and returns only policies where PathPattern
 // exactly matches the provided pattern string.
 //
 // Parameters:
-//   - pathPattern: The exact path pattern to match against policies
+//   - pathPattern: The exact pathPattern pattern to match against policies
 //
 // Returns:
 //   - []data.Policy: A slice of policies with matching PathPattern. Returns an
@@ -284,7 +284,7 @@ func ListPoliciesByPath(pathPattern string) ([]data.Policy, error) {
 		return nil, fmt.Errorf("failed to load policies: %w", err)
 	}
 
-	// Filter by path pattern
+	// Filter by pathPattern pattern
 	var result []data.Policy
 	for _, policy := range allPolicies {
 		if policy != nil && policy.PathPattern == pathPattern {

--- a/app/nexus/internal/state/base/policy_sqlite_test.go
+++ b/app/nexus/internal/state/base/policy_sqlite_test.go
@@ -60,7 +60,7 @@ func TestSQLitePolicy_CreateAndGet(t *testing.T) {
 			t.Errorf("Expected spiffeid pattern %s, got %s", policy.SPIFFEIDPattern, retrievedPolicy.SPIFFEIDPattern)
 		}
 		if retrievedPolicy.PathPattern != policy.PathPattern {
-			t.Errorf("Expected path pattern %s, got %s", policy.PathPattern, retrievedPolicy.PathPattern)
+			t.Errorf("Expected pathPattern pattern %s, got %s", policy.PathPattern, retrievedPolicy.PathPattern)
 		}
 		if !reflect.DeepEqual(retrievedPolicy.Permissions, policy.Permissions) {
 			t.Errorf("Expected permissions %v, got %v", policy.Permissions, retrievedPolicy.Permissions)
@@ -142,7 +142,7 @@ func TestSQLitePolicy_Persistence(t *testing.T) {
 			t.Errorf("Policy SPIFFE ID pattern not persisted correctly: expected %s, got %s", policy.SPIFFEIDPattern, retrievedPolicy.SPIFFEIDPattern)
 		}
 		if retrievedPolicy.PathPattern != policy.PathPattern {
-			t.Errorf("Policy path pattern not persisted correctly: expected %s, got %s", policy.PathPattern, retrievedPolicy.PathPattern)
+			t.Errorf("Policy pathPattern pattern not persisted correctly: expected %s, got %s", policy.PathPattern, retrievedPolicy.PathPattern)
 		}
 		if !reflect.DeepEqual(retrievedPolicy.Permissions, policy.Permissions) {
 			t.Errorf("Policy permissions not persisted correctly: expected %v, got %v", policy.Permissions, retrievedPolicy.Permissions)
@@ -332,7 +332,7 @@ func TestSQLitePolicy_CreateMultiplePolicies(t *testing.T) {
 		secondPolicy := data.Policy{
 			Name:            "second-policy",
 			SPIFFEIDPattern: "spiffe://example\\.org/second",
-			PathPattern:     "second/path/.*",
+			PathPattern:     "second/pathPattern/.*",
 			Permissions:     []data.PolicyPermission{data.PermissionWrite, data.PermissionList},
 		}
 
@@ -371,7 +371,7 @@ func TestSQLitePolicy_CreateMultiplePolicies(t *testing.T) {
 				secondPolicy.SPIFFEIDPattern, retrievedSecond.SPIFFEIDPattern)
 		}
 		if retrievedSecond.PathPattern != secondPolicy.PathPattern {
-			t.Errorf("Expected second policy path pattern %s, got %s",
+			t.Errorf("Expected second policy pathPattern pattern %s, got %s",
 				secondPolicy.PathPattern, retrievedSecond.PathPattern)
 		}
 		if !reflect.DeepEqual(retrievedSecond.Permissions, secondPolicy.Permissions) {
@@ -433,7 +433,7 @@ func TestSQLitePolicy_SpecialCharactersAndLongData(t *testing.T) {
 				policy.SPIFFEIDPattern, retrievedPolicy.SPIFFEIDPattern)
 		}
 		if retrievedPolicy.PathPattern != policy.PathPattern {
-			t.Errorf("Special character path pattern not preserved: expected %s, got %s",
+			t.Errorf("Special character pathPattern pattern not preserved: expected %s, got %s",
 				policy.PathPattern, retrievedPolicy.PathPattern)
 		}
 		if !reflect.DeepEqual(retrievedPolicy.Permissions, policy.Permissions) {
@@ -529,7 +529,7 @@ func TestSQLitePolicy_EncryptionWithDifferentKeys(t *testing.T) {
 				policy.SPIFFEIDPattern, retrievedPolicy.SPIFFEIDPattern)
 		}
 		if retrievedPolicy.PathPattern != policy.PathPattern {
-			t.Errorf("Policy path pattern corrupted: expected %s, got %s",
+			t.Errorf("Policy pathPattern pattern corrupted: expected %s, got %s",
 				policy.PathPattern, retrievedPolicy.PathPattern)
 		}
 		if !reflect.DeepEqual(retrievedPolicy.Permissions, policy.Permissions) {

--- a/app/nexus/internal/state/base/secret_sqlite_test.go
+++ b/app/nexus/internal/state/base/secret_sqlite_test.go
@@ -80,7 +80,7 @@ func TestSQLiteSecret_NewSecret(t *testing.T) {
 			t.Fatalf("Expected env.BackendStoreType()=Sqlite, got %v", env.BackendStoreType())
 		}
 
-		// Get the actual database path used by the system
+		// Get the actual database pathPattern used by the system
 		dataDir := config.SpikeNexusDataFolder()
 		dbPath := filepath.Join(dataDir, "spike.db")
 		t.Logf("Using SQLite database at: %s", dbPath)
@@ -109,7 +109,7 @@ func TestSQLiteSecret_NewSecret(t *testing.T) {
 		t.Logf("Found %d existing secrets after initialization (expected 0)", len(allSecrets))
 		if len(allSecrets) != 0 {
 			for path := range allSecrets {
-				t.Logf("  - Unexpected secret at path: %s", path)
+				t.Logf("  - Unexpected secret at pathPattern: %s", path)
 			}
 		}
 
@@ -128,7 +128,7 @@ func TestSQLiteSecret_NewSecret(t *testing.T) {
 		if secretBeforeUpsert != nil {
 			t.Fatalf("Expected LoadSecret to return nil for non-existent secret, got: %+v", secretBeforeUpsert)
 		}
-		t.Logf("✅ LoadSecret correctly returned nil for non-existent path")
+		t.Logf("✅ LoadSecret correctly returned nil for non-existent pathPattern")
 
 		err = UpsertSecret(path, values)
 		if err != nil {

--- a/app/nexus/internal/state/base/secret_test.go
+++ b/app/nexus/internal/state/base/secret_test.go
@@ -824,7 +824,7 @@ func TestSecretOperations_SpecialCharacters(t *testing.T) {
 			"/test/with.dots",
 			"/test/with_underscores",
 			"/test/with-dashes",
-			"/test/with/deep/nested/path",
+			"/test/with/deep/nested/pathPattern",
 		}
 
 		for _, path := range specialPaths {

--- a/app/spike/internal/cmd/policy/apply.go
+++ b/app/spike/internal/cmd/policy/apply.go
@@ -6,7 +6,6 @@ package policy
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
@@ -15,20 +14,6 @@ import (
 
 	"github.com/spiffe/spike/app/spike/internal/trust"
 )
-
-// normalizePath removes trailing slashes and ensures a consistent path format.
-func normalizePath(path string) string {
-	if path == "" {
-		return path
-	}
-
-	// Remove all trailing slashes except for the root path:
-	if path != "/" {
-		path = strings.TrimRight(path, "/")
-	}
-
-	return path
-}
 
 // newPolicyApplyCommand creates a new Cobra command for policy application.
 // It allows users to apply policies via the command line by specifying
@@ -151,9 +136,6 @@ func newPolicyApplyCommand(
 					return
 				}
 			}
-
-			// Normalize the path pattern
-			policy.PathPattern = normalizePath(policy.PathPattern)
 
 			// Convert permissions slice to comma-separated string
 			// for validation

--- a/app/spike/internal/cmd/policy/create.go
+++ b/app/spike/internal/cmd/policy/create.go
@@ -44,8 +44,8 @@ import (
 //
 //	spike policy create \
 //	    --name "web-service-policy" \
-//	    --spiffeid "^spiffe://example\.org/web-service/.*$" \
-//	    --path "^tenants/acme/creds/.*$" \
+//	    --spiffeid-pattern "^spiffe://example\.org/web-service/.*$" \
+//	    --path-pattern "^tenants/acme/creds/.*$" \
 //	    --permissions "read,write"
 //
 // The command will:

--- a/app/spike/internal/cmd/policy/list.go
+++ b/app/spike/internal/cmd/policy/list.go
@@ -29,21 +29,21 @@ import (
 //
 // Command usage:
 //
-//	list [--format=<format>] [--path=<pattern> | --spiffeid=<pattern>]
+//	list [--format=<format>] [--path-pattern=<pattern> | --spiffeid-pattern=<pattern>]
 //
 // Flags:
 //   - --format: Output format ("human" or "json", default is "human")
-//   - --path: Filter policies by a resource path pattern (e.g., '^secrets/.*$')
-//   - --spiffeid: Filter policies by a SPIFFE ID pattern (e.g., '^spiffe://example\.org/service/.*$')
+//   - --path-pattern: Filter policies by a resource path pattern (e.g., '^secrets/.*$')
+//   - --spiffeid-pattern: Filter policies by a SPIFFE ID pattern (e.g., '^spiffe://example\.org/service/.*$')
 //
-// Note: --path and --spiffeid flags cannot be used together.
+// Note: --path-pattern and --spiffeid-pattern flags cannot be used together.
 //
 // Example usage:
 //
 //	spike policy list
 //	spike policy list --format=json
-//	spike policy list --path="^secrets/db/.*$"
-//	spike policy list --spiffeid="^spiffe://example\.org/app$"
+//	spike policy list --path-pattern="^secrets/db/.*$"
+//	spike policy list --spiffeid-pattern="^spiffe://example\.org/app$"
 //
 // Example output for human format:
 //
@@ -97,7 +97,7 @@ func newPolicyListCommand(
 	)
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List policies, optionally filtering by path or SPIFFE ID",
+		Short: "List policies, optionally filtering by path pattern or SPIFFE ID pattern",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			trust.Authenticate(SPIFFEID)
@@ -113,11 +113,11 @@ func newPolicyListCommand(
 		},
 	}
 
-	cmd.Flags().StringVar(&pathPattern, "path", "",
+	cmd.Flags().StringVar(&pathPattern, "path-pattern", "",
 		"Resource path pattern, e.g., '^secrets/web/db$'")
-	cmd.Flags().StringVar(&SPIFFEIDPattern, "spiffeid", "",
+	cmd.Flags().StringVar(&SPIFFEIDPattern, "spiffeid-pattern", "",
 		"SPIFFE ID pattern, e.g., '^spiffe://example\\.org/service/finance$'")
-	cmd.MarkFlagsMutuallyExclusive("path", "spiffeid")
+	cmd.MarkFlagsMutuallyExclusive("path-pattern", "spiffeid-pattern")
 
 	addFormatFlag(cmd)
 	return cmd

--- a/docs-src/content/operations/release.md
+++ b/docs-src/content/operations/release.md
@@ -142,8 +142,8 @@ spike secret get /acme/db
 
 ```bash
 spike policy create --name=workload-can-read \
-  --path="/tenants/demo/db/*" \
-  --spiffeid="^spiffe://spike.ist/workload/*" \
+  --path-pattern="/tenants/demo/db/*" \
+  --spiffeid-pattern="^spiffe://spike.ist/workload/*" \
   --permissions="read"
 ```
 

--- a/docs-src/content/usage/commands/policy.md
+++ b/docs-src/content/usage/commands/policy.md
@@ -42,11 +42,10 @@ spike policy apply --file policy.yaml
 # Policy name - must be unique within the system
 name: "web-service-policy"
 
-# SPIFFE ID pattern for workload matching
-spiffeid: "^spiffe://example\\.org/web-service/$"
+# SPIFFE ID RegEx pattern for workload matching
+spiffeidPattern: "^spiffe://example\\.org/web-service/$"
 
-# Path pattern for access control
-# Note: Trailing slashes are automatically removed during normalization
+# Path RegEx pattern for access control
 pathPattern: "^secrets/web-service/db-[0-9]*$"
 
 # List of permissions to grant
@@ -55,41 +54,30 @@ permissions:
   - write
 ```
 
-### Path Normalization
-
-The `apply` command automatically normalizes paths by removing trailing slashes:
-
-```yaml
-# These paths are all normalized to the same value:
-path: "secrets/database/production"    # ✓ Normalized form
-path: "secrets/database/production/"   # → "secrets/database/production"
-path: "secrets/database/production//"  # → "secrets/database/production"
-```
-
-### Realistic Path Examples
+### Realistic SPIFFE ID Pattern and Path Pattern Examples
 
 ```yaml
 # Database secrets
 name: "database-policy"
-spiffeid: "^spiffe://example\.org/database$"
-path: "^secrets/database/production$"
+spiffeidPattern: "^spiffe://example\\.org/database$"
+pathPattern: "^secrets/database/production$"
 permissions: [read]
 
 # Web service configuration
 name: "web-service-policy"
-spiffeid: "^spiffe://example\.org/web-service$"
+spiffeid: "^spiffe://example\\.org/web-service$"
 path: "^secrets/web-service/config$"
 permissions: [read, write]
 
 # Cache credentials
 name: "cache-policy"
-spiffeid: "^spiffe://example\.org/cache/$"
+spiffeid: "^spiffe://example\\.org/cache/$"
 path: "^secrets/cache/redis/session$"
 permissions: [read]
 
 # Application environment variables
 name: "app-env-policy"
-spiffeid: "^spiffe://example\.org/app$"
+spiffeid: "^spiffe://example\\.org/app$"
 path: "^secrets/app/env/production$"
 permissions: [read, list]
 ```
@@ -97,7 +85,7 @@ permissions: [read, list]
 ### All Available Permissions
 ```yaml
 name: "admin-policy"
-spiffeid: "^spiffe://example\.org/admin$"
+spiffeid: "^spiffe://example\\.org/admin$"
 path: "secrets"
 permissions:
   - read    # Permission to read secrets
@@ -111,7 +99,7 @@ permissions:
 #### Flow Sequence for Permissions
 ```yaml
 name: "database-policy"
-spiffeid: "^spiffe://example\.org/database$"
+spiffeid: "^spiffe://example\\.org/database$"
 path: "^secrets/database/production$"
 permissions: [read, write, list]
 ```
@@ -119,8 +107,8 @@ permissions: [read, write, list]
 #### Quoted Values
 ```yaml
 name: "cache-policy"
-spiffeid: "^spiffe://example\.org/cache$"
-path: "^secrets/cache/redis$"
+spiffeidPattern: "^spiffe://example\\.org/cache$"
+pathPattern: "^secrets/cache/redis$"
 permissions:
   - "read"
   - "write"
@@ -134,8 +122,8 @@ to programmatically create your policies too:
 ```bash
 # Create your first policy
 spike policy create --name=my-service \
-  --path="^secrets/app$" \
-  --spiffeid="^spiffe://example\.org/service$" \
+  --path-pattern="^secrets/app$" \
+  --spiffeid-pattern="^spiffe://example\.org/service$" \
   --permissions=read
 
 # Verify your policy was created
@@ -196,20 +184,21 @@ When a workload attempts to access a resource in SPIKE:
 ### `spike policy list`
 
 ```bash
-spike policy list [--format=human|json] [--path=<pattern> | --spiffeid=<pattern>]
+spike policy list [--format=human|json] [--path-pattern=<pattern> | --spiffeid-pattern=<pattern>]
 ```
 
 Lists all policies in the system. Can be filtered by a resource path pattern or 
 a SPIFFE ID pattern.
 
-**Note:** `--path` and `--spiffeid` flags cannot be used together.
+**Note:** `--path-pattern` and `--spiffeid-pattern` flags cannot be used 
+together.
 
 ### `spike policy create`
 
 ```bash
 spike policy create --name=<name> \
-  --path=<path-pattern> \
-  --spiffeid=<spiffe-id-pattern> \
+  --path-pattern=<path-pattern> \
+  --spiffeid-pattern=<spiffe-id-pattern> \
   --permissions=<permissions>
 ```
 Creates a new policy with the specified parameters.
@@ -228,8 +217,8 @@ When using the `--file` flag, the YAML file should follow this structure:
 
 ```yaml
 name: policy-name
-spiffeid: ^spiffe://example\.org/service$
-path: ^secrets/database/production$
+spiffeidPattern: ^spiffe://example\.org/service$
+pathPattern: ^secrets/database/production$
 permissions:
   - read
   - write
@@ -331,15 +320,15 @@ Deletes a policy by ID or name. Requires confirmation.
 # Create a policy for a web service with read and write access
 spike policy create \
   --name=web-service \
-  --path="^secrets/web$" \
-  --spiffeid="^spiffe://example\.org/web$" \
+  --path-pattern="^secrets/web$" \
+  --spiffeid-pattern="^spiffe://example\.org/web$" \
   --permissions=read,write
 
 # Create a policy with multiple permissions
 spike policy create \
   --name=admin-service \
-  --path="secrets/" \
-  --spiffeid="^spiffe://example\.org/admin$" \
+  --path-pattern="secrets/" \
+  --spiffeid-pattern="^spiffe://example\.org/admin$" \
   --permissions=read,write,list
 
 # Apply a policy using a YAML file
@@ -375,7 +364,7 @@ For example:
 * Whereas, `^secrets/db$` only matches `secrets/db` and nothing else 
   (*`global/secrets/db` and `secrets/db/local` will not match*)
 
-Thus, for precise control, you might want to include `^` and `$` at the 
+Thus, for precise control, you are encouraged to include `^` and `$` at the 
 beginning and end of your patterns respectively for an exact match.
 
 ## How Regular Expressions are Used For Policy Matching
@@ -418,48 +407,20 @@ specified rules and allow for flexibility with wildcards or exact matches.
 ### Path Pattern Examples
 
 ```txt
-secrets/               # All resources in the secrets directory
-secrets/database/      # Only resources in the database subdirectory  
-secrets/database/creds # Only the specific creds resource
+^secrets/               # All resources in the secrets directory
+^secrets/database/      # Only resources in the database subdirectory  
+^secrets/database/creds # Only the specific creds resource
 
 # You can provide regular expressions for a more fine-tuned
 # pattern match:
 ^secrets/db-[123]$ # Matches secrets/db-2, but not secrets/db-4.
 ```
 
-## Path Patterns in SPIKE
-
-Path patterns in **SPIKE** are designed to provide flexibility but also follow
-certain conventions for clarity and usability. While the path pattern is
-suggested (*but not mandated*) to look like a UNIX-style path for familiarity, 
-**SPIKE secret paths DO NOT start with a leading slash**.
-
-This is because **SPIKE paths represent logical key namespaces**, not
-hierarchical filesystem paths. They are always relative to the secrets engine
-mount point, making the leading slash redundant and potentially confusing.
-
-#### Example:
-
-* **Correct:** `secrets/app/config`
-* **Redundant/Confusing:** `/secrets/app/config`
-
-Additionally, although there is currently no restriction on how the path is
-formed, it is worth noting that future versions of **SPIKE** may restrict paths 
-from having a trailing slash to avoid ambiguity and maintain consistency
-in naming practices.
-
-#### Best Practices for Path Patterns:
-
-1. Avoid leading slashes.
-2. Avoid trailing slashes to ensure forward compatibility.
-3. Use descriptive and meaningful names that reflect the resource's purpose or
-   hierarchy.
-
 ### SPIFFE ID Pattern Examples
 ```
-spiffe://example.org/              # Workloads in the example.org trust domain
-spiffe://example.org/web/          # Only web workloads
-^spiffe://example.org/web/server$  # Only the specific web server workload
+^spiffe://example\.org/             # Workloads in the example.org trust domain
+^spiffe://example\.org/web/         # Only web workloads
+^spiffe://example\.org/web/server$  # Only the specific web server workload
 ```
 
 ## Best Practices

--- a/docs-src/content/usage/commands/secret.md
+++ b/docs-src/content/usage/commands/secret.md
@@ -63,6 +63,25 @@ their verified identity, following zero-trust security principles.
 Secret paths in **SPIKE** have specific syntax requirements and recommended 
 conventions to ensure consistency and avoid common pitfalls.
 
+Paths in **SPIKE** are designed to provide flexibility but also follow
+certain conventions for clarity and usability. While the path is
+suggested (*but not mandated*) to look like a UNIX-style path for familiarity,
+**SPIKE secret paths SHOULD NOT start with a leading slash**.
+
+This is because **SPIKE paths represent logical key namespaces**, not
+hierarchical filesystem paths. They are always relative to the secrets engine
+mount point, making the leading slash redundant and potentially confusing.
+
+Additionally, although there is currently no restriction on how the path is
+formed, it is worth noting that future versions of **SPIKE** may restrict paths
+from having a trailing slash to avoid ambiguity and maintain consistency
+in naming practices.
+
+#### Example:
+
+* **Correct:** `secrets/app/config`
+* **Redundant/Confusing:** `/secrets/app/config`
+
 ### Path Format Requirements
 
 All secret paths must match the regex pattern:
@@ -104,7 +123,8 @@ conventions are strongly recommended:
 
 * Use consistent prefixes like `secrets/` or `credentials/` as the first segment
 * Organize paths by application, service, or environment
-* Include version indicators in the path for managed rotation (e.g., `secrets/database/v1/credentials`)
+* Include version indicators in the path for managed rotation
+  (*e.g., `secrets/database/v1/credentials`*)
 * Use clear, descriptive names that indicate the purpose of the secret
 * Keep paths reasonably short while maintaining clarity
 
@@ -123,7 +143,8 @@ secrets/api/external/stripe/key   # External API credentials with service name
 * Use separate paths for different environments (dev, staging, production)
 * Limit the number of key-value pairs in a single secret for better management
 * Use version history for auditing and rollback capability
-* Create specific policies that grant the minimum required access to each secret path
+* Create specific policies that grant the minimum required access to each 
+  secret path
 * Regularly rotate sensitive secrets like API keys and passwords
 * Use secret delete and undelete for safe secret lifecycle management
 * Validate paths are properly formatted and follow naming conventions

--- a/examples/consume-secrets/demo-create-policy.sh
+++ b/examples/consume-secrets/demo-create-policy.sh
@@ -5,21 +5,21 @@
 # \\\\\\\ SPDX-License-Identifier: Apache-2.
 
 if ! command -v spike &> /dev/null; then
-    echo "Error: 'spike' command not found. Please add ./spike to your PATH."
-    exit 1
+  echo "Error: 'spike' command not found. Please add ./spike to your PATH."
+  exit 1
 fi
 
 spike policy create --name=workload-can-read \
- --path="^tenants/demo/db/.*$" \
- --spiffeid="^spiffe://spike\.ist/workload/.*$" \
+ --path-pattern="^tenants/demo/db/.*$" \
+ --spiffeid-pattern="^spiffe://spike\.ist/workload/.*$" \
  --permissions="read"
 
 spike policy create --name=workload-can-write \
- --path="^tenants/demo/db/.*$" \
- --spiffeid="^spiffe://spike\.ist/workload/.*$" \
+ --path-pattern="^tenants/demo/db/.*$" \
+ --spiffeid-pattern="^spiffe://spike\.ist/workload/.*$" \
  --permissions="write"
 
 # spike policy create --name=workload-can-rw \
-#  --path="^tenants/demo/db/.*$" \
-#  --spiffeid="^spiffe://spike\.ist/workload/.*$" \
+#  --path-pattern="^tenants/demo/db/.*$" \
+#  --spiffeid-pattern="^spiffe://spike\.ist/workload/.*$" \
 #  --permissions="read,write"

--- a/jira.xml
+++ b/jira.xml
@@ -229,6 +229,25 @@
       }
     </issue>
     <issue>
+      unit tests are failing in CI because it cannot find the db path.
+
+    </issue>
+    <issue>
+      The `apply` command automatically normalizes the path patterns by removing
+      trailing slashes:
+
+      ^ we don't need this normalization as
+      1. paths are keys, and the user may intentionally want to include multiple slashes
+         that's not against spec.
+      2. something like ^test/path/one//$ is not normalized anyway.
+
+      once you implement the fix, update the documentation too.
+    </issue>
+    <issue>
+      remove single wildcard special case from
+      spiffeid pattern and path pattern match.
+    </issue>
+    <issue>
       add to instructions for relase
       make audit
       make test


### PR DESCRIPTION
Since policy path are regular expression, removing trailing slash from them (i.e normalizing them) can be confusing and may cause more harm than good, and result in edge cases where the user actually wants the traling slash.

Technically, the "path" in SPIKE secrets are NOT unix paths, they are merely keys; and the specification allows the key to have double slashes, trailing slashes etc. -- the best we can do is to "strongly discourage" the user from using weird paths, while stil giving them the freedom to do so if they want to do so.