### PR TITLE
feat(link-check): add the link check lychee-action

### DIFF
--- a/.github/workflows/docs-link-check.yaml
+++ b/.github/workflows/docs-link-check.yaml
@@ -1,0 +1,48 @@
+name: Docs Link Check
+
+on:
+  pull_request:
+    paths: ["docs/**", ".github/workflows/docs-link-check.yaml"]
+  push:
+    branches: [main]
+    paths: ["docs/**"]
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --base-url https://spike.ist
+            --cache --max-cache-age 1d
+            --timeout 60 --max-retries 3 --retry-wait-time 3
+            --accept 200,206,403,429
+            docs
+          format: markdown
+          output: ./lychee/out.md
+          fail: false
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report
+          path: ./lychee/out.md
+
+      - name: Comment on PR with report
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: ./lychee/out.md

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,11 @@
+timeout = 60
+max_retries = 3 
+retry_wait_time = 3 
+exclude_mail = true
+exclude_all_private = true
+accept = [200, 206, 403, 429]
+
+[remap]
+"^/+"   = "https://spike.ist/"
+"@/+"   = "https://spike.ist/"
+"^file:///" = "https://spike.ist/"


### PR DESCRIPTION
This pull request adds automated link validation for documentation files using the Lychee GitHub Action.

- Runs on every push or pull request affecting **docs/****

- Caches previous scan results for faster checks

- Reports broken or unreachable links directly in the PR checks

This ensures all documentation links remain valid and up to date.