### PR TITLE
Relax ctx dependency in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,45 @@
 ## IMPORTANT: You Have Persistent Memory
 
 This project uses Context (`ctx`) for context persistence across sessions.
-**Your memory is NOT ephemeral**: it lives in the context directory.
+When `ctx` is installed, **your memory is NOT ephemeral**: it lives in the
+context directory.
+
+`ctx` is an optional companion tool: helpful, but never required to build,
+test, or contribute to this project. If it is not installed, offer the
+setup note in "On Session Start" once, then skip every `ctx`-dependent
+instruction in this file and help with the task at hand as usual.
 
 ## On Session Start
 
-1. **Run `ctx system bootstrap`**: CRITICAL, not optional.
-   This tells you where the context directory is.
-   If it returns any error, relay the error output to the user
-   verbatim, point them at
-   https://ctx.ist/home/getting-started/ for setup, and STOP.
-   Do not try to activate, initialize, or otherwise recover: **those
-   are the user's decisions**. Wait for their next instruction.
+1. **Run `ctx system bootstrap`**: it tells you where the context
+   directory is.
+
+   **If the `ctx` command is not found**: `ctx` is optional, so this is
+   not an error. Mention once that the user can enable persistent context
+   by cloning the repository and installing the plugin from the local
+   clone (releases are infrequent, so marketplace versions may lag behind
+   the repository):
+
+   ```bash
+   git clone https://github.com/ActiveMemory/ctx.git ~/WORKSPACE/ctx
+   ```
+
+   Then, inside Claude Code:
+
+   ```
+   /plugin marketplace add ~/WORKSPACE/ctx
+   /plugin install ctx@activememory-ctx
+   ```
+
+   The `ctx` binary is installed separately; see
+   https://ctx.ist/home/getting-started/. Afterward, continue with the
+   user's task and work without persistent context until `ctx` is set up.
+
+   **If `ctx` is installed but returns an error**: relay the error output
+   to the user verbatim, point them at
+   https://ctx.ist/home/getting-started/ for setup, and STOP. Do not try
+   to activate, initialize, or otherwise recover: **those are the user's
+   decisions**. Wait for their next instruction.
 2. **Read AGENT_PLAYBOOK.md** from the context directory: it explains
    how to use this system
 3. **Run `ctx agent`** for a content summary

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/spiffe/spike
 
 go 1.25.5
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/cloudflare/circl v1.6.3


### PR DESCRIPTION
ctx is a helper tool; it must not gate contribution, and we cannot
mandate tools like that. The ctx-managed block previously ordered the
agent to STOP when `ctx system bootstrap` failed, which walls off a
fresh clone (no plugin, no binary) before any work happens. The block
now frames ctx as an optional companion: when the command is missing,
the agent recommends cloning the ctx repository and installing the
plugin from the local clone (marketplace releases may lag), then
continues with the task. The relay-verbatim-and-STOP behavior remains
for an installed ctx that returns an error.

The same softening was applied upstream to the ctx templates so it
survives ctx init re-runs; this copy matches the new template.

Spec: specs/introduce-ctx.md
Signed-off-by: Volkan Özçelik <volkan.ozcelik@broadcom.com>
