### PR TITLE
perf: use indexed LoadPolicy in UpsertPolicy instead of full scan

### DIFF
--- a/.context/TASKS.md
+++ b/.context/TASKS.md
@@ -53,14 +53,14 @@ the name-based policy work.
 
 ### Phase 4: Policy & Secrets `#priority:medium`
 - [ ] Add a `list` permission type; scope `spike secret list` to the caller's allowed path patterns → ideas/research-list-permission.md #source:jira.xml #added:2026-07-14
-- [ ] Add `LoadPolicyByName` for indexed O(1) lookup (UpsertPolicy currently scans all policies) #source:jira.xml #added:2026-07-14
+- [x] Add `LoadPolicyByName` for indexed O(1) lookup (UpsertPolicy currently scans all policies) #source:jira.xml #added:2026-07-14 #done:2026-07-14 #branch:fix/upsert-policy-indexed-lookup (used the existing `LoadPolicy(ctx, name)` indexed lookup; no new method needed)
 - [ ] Reject empty id/path for both policies and secrets #source:jira.xml #added:2026-07-14
 - [ ] Substring/partial-match filtering for `policy list` and `secret list` (today requires the exact regex) #source:jira.xml #added:2026-07-14
 - [ ] Refactor `app/spike/internal/cmd/secret/get.go` to extract the repeated marshal-and-print helpers #source:jira.xml #added:2026-07-14
 
 ### Phase 5: Ops & Config `#priority:low`
-- [ ] Wire the unused `DatabaseOperationTimeout()` into the DB path → ideas/research-db-resilience.md #source:jira.xml #added:2026-07-14
-- [ ] Move `const maxShardID = 1000` to env-var configuration #source:jira.xml #added:2026-07-14
+- [ ] Wire the SDK's `env.DatabaseOperationTimeoutVal()` (spike-sdk-go config/env/database.go) into the Nexus DB path; SPIKE does not call it yet → ideas/research-db-resilience.md #source:jira.xml #added:2026-07-14 (retargeted 2026-07-14: the old in-repo accessor was removed and the accessor now lives in the SDK)
+- [-] Move `const maxShardID = 1000` to env-var configuration #source:jira.xml #added:2026-07-14 #skipped:2026-07-14 (obsolete: the constant no longer exists anywhere in the repo or SDK)
 - [ ] Add a configurable SVID-source acquisition timeout (go-spiffe context) so lookups don't wait forever #source:jira.xml #added:2026-07-14
 - [ ] Add a Nexus `/status` endpoint; Pilot warns when Nexus not ready; Bootstrap uses it instead of the k8s Jobs API #source:jira.xml #added:2026-07-14
 

--- a/app/nexus/internal/state/backend/interface.go
+++ b/app/nexus/internal/state/backend/interface.go
@@ -160,18 +160,18 @@ type Backend interface {
 	//     on success.
 	StorePolicy(ctx context.Context, policy data.Policy) *sdkErrors.SDKError
 
-	// LoadPolicy retrieves a policy by its ID from the backend storage.
+	// LoadPolicy retrieves a policy by its name from the backend storage.
 	//
 	// Parameters:
 	//   - ctx: Context for managing request lifetime and cancellation.
-	//   - id: The unique identifier of the policy to retrieve.
+	//   - name: The name of the policy to retrieve.
 	//
 	// Returns:
 	//   - *data.Policy: The policy object, or nil if not found.
 	//   - *sdkErrors.SDKError: An error if the operation fails. Returns nil
 	//     on success.
 	LoadPolicy(
-		ctx context.Context, id string,
+		ctx context.Context, name string,
 	) (*data.Policy, *sdkErrors.SDKError)
 
 	// LoadAllPolicies retrieves all policies stored in the backend.
@@ -188,17 +188,17 @@ type Backend interface {
 		ctx context.Context,
 	) (map[string]*data.Policy, *sdkErrors.SDKError)
 
-	// DeletePolicy removes a policy object identified by the given ID from
+	// DeletePolicy removes a policy object identified by the given name from
 	// the backend storage.
 	//
 	// Parameters:
 	//   - ctx: Context for managing request lifetime and cancellation.
-	//   - id: The unique identifier of the policy to delete.
+	//   - name: The name of the policy to delete.
 	//
 	// Returns:
 	//   - *sdkErrors.SDKError: An error if the operation fails. Returns nil
 	//     on success.
-	DeletePolicy(ctx context.Context, id string) *sdkErrors.SDKError
+	DeletePolicy(ctx context.Context, name string) *sdkErrors.SDKError
 
 	// GetCipher retrieves the AEAD cipher used for encryption and decryption.
 	//

--- a/app/nexus/internal/state/base/policy.go
+++ b/app/nexus/internal/state/base/policy.go
@@ -6,6 +6,7 @@ package base
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"time"
 
@@ -104,19 +105,13 @@ func UpsertPolicy(policy data.Policy) (data.Policy, *sdkErrors.SDKError) {
 
 	ctx := context.Background()
 
-	// Check for existing policy with the same name
-	allPolicies, loadErr := persist.Backend().LoadAllPolicies(ctx)
-	if loadErr != nil {
+	// Look up any existing policy by name directly. This is an indexed
+	// lookup on the name primary key, so it avoids loading and decrypting
+	// every policy just to check for one. A missing policy is expected on
+	// create and is not an error.
+	existingPolicy, loadErr := persist.Backend().LoadPolicy(ctx, policy.Name)
+	if loadErr != nil && !errors.Is(loadErr, sdkErrors.ErrEntityNotFound) {
 		return data.Policy{}, sdkErrors.ErrEntityLoadFailed.Wrap(loadErr)
-	}
-
-	var existingPolicy *data.Policy
-	for _, p := range allPolicies {
-		if p.Name == policy.Name {
-			pCopy := p
-			existingPolicy = pCopy
-			break
-		}
 	}
 
 	// Compile and validate patterns


### PR DESCRIPTION
UpsertPolicy called LoadAllPolicies and looped to find one policy by name, loading and decrypting every policy on every upsert. Switch to the existing LoadPolicy(ctx, name) indexed lookup (name is the primary key), treating ErrEntityNotFound as the create case. Behavior is unchanged; cost drops from O(n) with full decryption to a single indexed read.

Also fix stale "by its ID" doc comments and id parameter names on the LoadPolicy and DeletePolicy backend interface methods (policies are keyed by name).

Context housekeeping in .context/TASKS.md: mark the lookup task done; skip the obsolete maxShardID task (the constant no longer exists); and retarget the DB-operation-timeout task at the SDK's env.DatabaseOperationTimeoutVal(), where that accessor now lives.

Spec: TBD