### PR TITLE
Worktree spike binary preflight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ bootstrap-linux-arm64.sum.txt
 # For SKD debugging while building images
 spike-sdk-go
 
+# SPIRE source clone (build-spire.sh now uses a temp dir; guard against a
+# repo-root clone from older runs or a manual `git clone`).
+/spire/
+
 # WSL
 *:Zone.Identifier
 

--- a/app/nexus/internal/route/acl/policy/delete_intercept.go
+++ b/app/nexus/internal/route/acl/policy/delete_intercept.go
@@ -20,21 +20,21 @@ import (
 //
 // The function performs the following validations in order:
 //   - Extracts and validates the peer SPIFFE ID from the request
-//   - Validates the policy ID format
+//   - Validates the policy name format
 //   - Checks if the peer has write permission for the policy access path
 //
 // If any validation fails, an appropriate error response is written to the
 // ResponseWriter and an error is returned.
 //
 // Parameters:
-//   - request: The policy deletion request containing the policy ID
+//   - request: The policy deletion request containing the policy name
 //   - w: The HTTP response writer for error responses
 //   - r: The HTTP request containing the peer SPIFFE ID
 //
 // Returns:
 //   - *sdkErrors.SDKError: nil if all validations pass,
 //     ErrAccessUnauthorized if authentication or authorization fails,
-//     ErrDataInvalidInput if policy ID validation fails
+//     ErrDataInvalidInput if policy name validation fails
 func guardPolicyDeleteRequest(
 	request reqres.PolicyDeleteRequest, w http.ResponseWriter, r *http.Request,
 ) *sdkErrors.SDKError {
@@ -47,7 +47,11 @@ func guardPolicyDeleteRequest(
 		return authErr
 	}
 
-	return net.RespondErrOnBadPolicyID(
-		request.ID, w, reqres.PolicyDeleteResponse{}.BadRequest(),
+	// SPIKE policies are keyed by name; the SDK's PolicyDeleteRequest
+	// still exposes that identifier as ID, so request.ID holds the policy
+	// name and must be validated as a name, not as a UUID. See issue #250
+	// for the pending SDK field rename.
+	return net.RespondErrOnBadName(
+		request.ID, reqres.PolicyDeleteResponse{}.BadRequest(), w,
 	)
 }

--- a/app/nexus/internal/route/acl/policy/get_intercept.go
+++ b/app/nexus/internal/route/acl/policy/get_intercept.go
@@ -20,21 +20,21 @@ import (
 //
 // The function performs the following validations in order:
 //   - Extracts and validates the peer SPIFFE ID from the request
-//   - Validates the policy ID format
+//   - Validates the policy name format
 //   - Checks if the peer has read permission for the policy access path
 //
 // If any validation fails, an appropriate error response is written to the
 // ResponseWriter and an error is returned.
 //
 // Parameters:
-//   - request: The policy read request containing the policy ID
+//   - request: The policy read request containing the policy name
 //   - w: The HTTP response writer for error responses
 //   - r: The HTTP request containing the peer SPIFFE ID
 //
 // Returns:
 //   - *sdkErrors.SDKError: nil if all validations pass,
 //     ErrAccessUnauthorized if authentication or authorization fails,
-//     ErrDataInvalidInput if policy ID validation fails
+//     ErrDataInvalidInput if policy name validation fails
 func guardPolicyReadRequest(
 	request reqres.PolicyReadRequest, w http.ResponseWriter, r *http.Request,
 ) *sdkErrors.SDKError {
@@ -47,7 +47,11 @@ func guardPolicyReadRequest(
 		return authErr
 	}
 
-	return net.RespondErrOnBadPolicyID(
-		request.ID, w, reqres.PolicyReadResponse{}.BadRequest(),
+	// SPIKE policies are keyed by name; the SDK's PolicyReadRequest still
+	// exposes that identifier as ID, so request.ID holds the policy name
+	// and must be validated as a name, not as a UUID. See issue #250 for
+	// the pending SDK field rename.
+	return net.RespondErrOnBadName(
+		request.ID, reqres.PolicyReadResponse{}.BadRequest(), w,
 	)
 }

--- a/app/spike/internal/cmd/policy/format.go
+++ b/app/spike/internal/cmd/policy/format.go
@@ -19,8 +19,9 @@ import (
 
 // formatPoliciesOutput formats the output of policy list items based on the
 // format flag. It supports human/plain, json, and yaml formats. For human
-// format, it creates a readable tabular representation. For JSON/YAML formats,
-// it marshals the policies to the appropriate structured format.
+// format, it creates a readable list of policy names (policies are keyed by
+// name; there is no separate ID). For JSON/YAML formats, it marshals the
+// policies to the appropriate structured format.
 //
 // If the format flag is invalid, it returns an error message.
 // If the "policies" list is empty, it returns an appropriate message based on
@@ -28,7 +29,7 @@ import (
 //
 // Parameters:
 //   - cmd: The Cobra command containing the format flag
-//   - policies: The policy list items to format (contains ID and Name only)
+//   - policies: The policy list items to format
 //
 // Returns:
 //   - string: The formatted output or error message
@@ -73,7 +74,6 @@ func formatPoliciesOutput(
 		result.WriteString("POLICIES\n========\n\n")
 
 		for _, policy := range *policies {
-			result.WriteString(fmt.Sprintf("ID: %s\n", policy.ID))
 			result.WriteString(fmt.Sprintf("Name: %s\n", policy.Name))
 			result.WriteString("--------\n\n")
 		}
@@ -120,7 +120,6 @@ func formatPolicy(cmd *cobra.Command, policy *data.Policy) string {
 		var result strings.Builder
 		result.WriteString("POLICY DETAILS\n=============\n\n")
 
-		result.WriteString(fmt.Sprintf("ID: %s\n", policy.ID))
 		result.WriteString(fmt.Sprintf("Name: %s\n", policy.Name))
 		result.WriteString(fmt.Sprintf("SPIFFE ID Pattern: %s\n",
 			policy.SPIFFEIDPattern))

--- a/app/spike/internal/cmd/policy/format_test.go
+++ b/app/spike/internal/cmd/policy/format_test.go
@@ -104,9 +104,9 @@ func TestFormatPoliciesOutput_HumanFormat(t *testing.T) {
 		t.Error("Human format should contain 'POLICIES' header")
 	}
 
-	// Check policy fields are present (PolicyListItem only has ID and Name)
+	// The human format prints only the name; policies are keyed by name
+	// and the vestigial ID is not shown.
 	expectedFields := []string{
-		"ID: 123e4567-e89b-12d3-a456-426614174000",
 		"Name: test-policy",
 	}
 
@@ -200,7 +200,6 @@ func TestFormatPolicy_HumanFormat(t *testing.T) {
 
 	// Check all fields are present
 	expectedFields := []string{
-		"ID: 123e4567-e89b-12d3-a456-426614174000",
 		"Name: admin-policy",
 		"SPIFFE ID Pattern: ^spiffe://example\\.org/admin/.*$",
 		"Path Pattern: ^.*$",

--- a/app/spike/internal/cmd/policy/list.go
+++ b/app/spike/internal/cmd/policy/list.go
@@ -51,31 +51,23 @@ import (
 //	spike policy list --path-pattern="^secrets/db/.*$"
 //	spike policy list --spiffeid-pattern="^spiffe://example\.org/app$"
 //
-// Example output for human format:
+// Example output for human format (the list shows policy names only; use
+// `spike policy get` for the full details of a policy):
 //
 //	POLICIES
 //	========
 //
-//	ID: policy-123
 //	Name: web-service-policy
-//	SPIFFE ID Pattern: ^spiffe://example\.org/web-service/.*$
-//	Path Pattern: ^secrets/db/.*$
-//	Permissions: read, write
-//	Created At: 2024-01-01T00:00:00Z
-//	Created By: user-abc
 //	--------
 //
-// Example output for JSON format:
+// Example output for JSON format (the "id" field is always empty; policies
+// are keyed by name, and the field awaits the SDK rename tracked in issue
+// #250):
 //
 //	[
 //	  {
-//	    "id": "policy-123",
-//	    "name": "web-service-policy",
-//	    "spiffeIdPattern": "^spiffe://example\.org/web-service/.*$",
-//	    "pathPattern": "^tenants/demo/db$",
-//	    "permissions": ["read", "write"],
-//	    "createdAt": "2024-01-01T00:00:00Z",
-//	    "createdBy": "user-abc"
+//	    "id": "",
+//	    "name": "web-service-policy"
 //	  }
 //	]
 //

--- a/hack/bare-metal/build/build-spire.sh
+++ b/hack/bare-metal/build/build-spire.sh
@@ -5,8 +5,27 @@
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
 # This is a simple way to create a single-node SPIRE development setup.
-git clone --single-branch --branch v1.11.2 https://github.com/spiffe/spire.git
-cd spire || exit
+# It builds the SPIRE server and agent from source and installs them into
+# /usr/local/bin. The source is cloned into a temporary directory that is
+# removed on exit, so the repository working tree stays clean.
+
+set -euo pipefail
+
+SPIRE_VERSION="v1.11.2"
+
+# Clone into a temporary directory and always clean it up on exit, even on
+# failure. Leaving the clone behind would pollute the working tree and break
+# `make audit` (gofmt scans it).
+CLONE_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$CLONE_DIR"
+}
+trap cleanup EXIT
+
+git clone --single-branch --branch "$SPIRE_VERSION" \
+  https://github.com/spiffe/spire.git "$CLONE_DIR"
+
+cd "$CLONE_DIR"
 go build ./cmd/spire-server
 go build ./cmd/spire-agent
 sudo mv spire-server /usr/local/bin

--- a/hack/bare-metal/startup/start.sh
+++ b/hack/bare-metal/startup/start.sh
@@ -159,32 +159,53 @@ if [ -z "$SPIKE_SKIP_SPIKE_BUILD" ]; then
   fi
 else
   echo "SPIKE_SKIP_SPIKE_BUILD is set, skipping SPIKE build."
+fi
 
-  # Only check for binaries if we're skipping the build step
-  echo "Checking for required SPIKE binaries..."
-  REQUIRED_BINARIES=("spike" "nexus" "keeper" "bootstrap")
-  MISSING_BINARIES=()
+# Preflight: make sure the SPIKE binaries are on PATH.
+#
+# build-spike.sh compiles them into ./bin, but this script and its child
+# scripts invoke them as bare commands (spike, nexus, keeper, bootstrap,
+# demo), so the bin directory must also be on PATH. The check runs after
+# the build step because on a fresh clone the binaries do not exist until
+# the build produces them. Failing here, before any SPIRE or SPIKE
+# process starts, is far more helpful than a bare "spike: command not
+# found" surfacing halfway through startup.
+check_spike_binaries() {
+  local missing=()
 
-  for binary in "${REQUIRED_BINARIES[@]}"; do
-    if ! command -v "$binary" >/dev/null 2>&1; then
-      MISSING_BINARIES+=("$binary")
+  for b in spike nexus keeper bootstrap demo; do
+    if ! command -v "$b" >/dev/null 2>&1; then
+      missing+=("$b")
     fi
   done
 
-  if [ ${#MISSING_BINARIES[@]} -gt 0 ]; then
-    echo "Error: The following required binaries are not found in PATH:"
-    for missing in "${MISSING_BINARIES[@]}"; do
-      echo "  - $missing"
-    done
-    echo ""
-    echo "Please build SPIKE binaries first by running:"
-    echo "  ./hack/bare-metal/build/build-spike.sh"
-    echo ""
-    echo "Or unset SPIKE_SKIP_SPIKE_BUILD to build them automatically."
-    exit 1
+  if [ ${#missing[@]} -eq 0 ]; then
+    echo "All required SPIKE binaries found on PATH."
+    return 0
   fi
 
-  echo "All required SPIKE binaries found."
+  echo "" >&2
+  echo "Error: required SPIKE binaries were not found on your PATH:" >&2
+  for m in "${missing[@]}"; do
+    echo "  - $m" >&2
+  done
+  echo "" >&2
+  echo "To build them into ./bin:" >&2
+  echo "  make build" >&2
+  echo "" >&2
+  echo "Then add the bin directory to your PATH:" >&2
+  echo "  export PATH=\"\$PATH:$(pwd)/bin\"" >&2
+  echo "" >&2
+  echo "Then verify with:" >&2
+  echo "  command -v spike nexus keeper bootstrap demo" >&2
+  echo "" >&2
+  echo "See https://spike.ist/development/bare-metal/ for details." >&2
+  return 1
+}
+
+if ! check_spike_binaries; then
+  echo "SPIKE binary preflight check failed. Exiting..." >&2
+  exit 1
 fi
 
 # Start SPIRE server in background and save its PID
@@ -473,7 +494,7 @@ echo "> Everything is set up."
 echo "> You can now experiment with SPIKE."
 echo ">"
 echo "<<"
-echo "> >> To begin, run './spike' on a separate terminal window."
+echo "> >> To begin, run 'spike' on a separate terminal window."
 echo "<<"
 echo ">"
 echo "> When you are done with your experiments, you can press 'Ctrl+C'"

--- a/hack/bare-metal/startup/start.sh
+++ b/hack/bare-metal/startup/start.sh
@@ -119,7 +119,7 @@ check_spire_binaries() {
   echo "binaries on your PATH." >&2
   echo "" >&2
   echo "To build and install them (SPIRE v1.11.2 into /usr/local/bin):" >&2
-  echo "  ./hack/bare-metal/build/build-spire.sh" >&2
+  echo "  make build-spire" >&2
   echo "" >&2
   echo "If you already have them elsewhere, add that directory to PATH:" >&2
   echo "  export PATH=\"/path/to/spire/bin:\$PATH\"" >&2

--- a/hack/bare-metal/startup/start.sh
+++ b/hack/bare-metal/startup/start.sh
@@ -420,26 +420,55 @@ if [ $POLICY_EXIT_CODE -ne 0 ]; then
   POLICY_VALIDATION_FAILED=true
 fi
 
-# Validate expected policy output (warnings only, no exit)
+# Validate expected policy output (warnings only, no exit).
+# `spike policy list` prints one "Name: <policy>" block per policy;
+# policies are keyed by name, and the list shows no other fields.
 echo "$POLICY_OUTPUT" | grep -q "POLICIES" || \
   { echo "WARNING: Missing 'POLICIES' header in output"; POLICY_VALIDATION_FAILED=true; }
-echo "$POLICY_OUTPUT" | grep -qE '^ID[[:space:]]+NAME$' || \
-  { echo "WARNING: Missing 'ID NAME' header in output"; POLICY_VALIDATION_FAILED=true; }
-echo "$POLICY_OUTPUT" | grep -q "workload-can-read" || \
+echo "$POLICY_OUTPUT" | grep -q "Name: workload-can-read" || \
   { echo "WARNING: Missing 'workload-can-read' policy"; POLICY_VALIDATION_FAILED=true; }
-echo "$POLICY_OUTPUT" | grep -q "workload-can-write" || \
+echo "$POLICY_OUTPUT" | grep -q "Name: workload-can-write" || \
   { echo "WARNING: Missing 'workload-can-write' policy"; POLICY_VALIDATION_FAILED=true; }
-echo "$POLICY_OUTPUT" | grep -q "Permissions: read" || \
+
+# Permissions are only visible via `spike policy get`; the demo policies
+# carry one permission each (read and write, respectively). This also
+# exercises the get-by-name path end to end.
+POLICY_READ_OUTPUT=$(spike policy get workload-can-read 2>&1)
+POLICY_READ_EXIT_CODE=$?
+
+if [ $POLICY_READ_EXIT_CODE -ne 0 ]; then
+  echo "WARNING: Policy get workload-can-read failed" \
+    "with exit code $POLICY_READ_EXIT_CODE"
+  echo "Output:"
+  echo "$POLICY_READ_OUTPUT"
+  POLICY_VALIDATION_FAILED=true
+fi
+echo "$POLICY_READ_OUTPUT" | grep -q "Permissions: read" || \
   { echo "WARNING: Missing read permission"; POLICY_VALIDATION_FAILED=true; }
-echo "$POLICY_OUTPUT" | grep -q "Permissions: write" || \
+
+POLICY_WRITE_OUTPUT=$(spike policy get workload-can-write 2>&1)
+POLICY_WRITE_EXIT_CODE=$?
+
+if [ $POLICY_WRITE_EXIT_CODE -ne 0 ]; then
+  echo "WARNING: Policy get workload-can-write failed" \
+    "with exit code $POLICY_WRITE_EXIT_CODE"
+  echo "Output:"
+  echo "$POLICY_WRITE_OUTPUT"
+  POLICY_VALIDATION_FAILED=true
+fi
+echo "$POLICY_WRITE_OUTPUT" | grep -q "Permissions: write" || \
   { echo "WARNING: Missing write permission"; POLICY_VALIDATION_FAILED=true; }
 
 if [ "$POLICY_VALIDATION_FAILED" = true ]; then
   echo ""
   echo "=========================================="
   echo "POLICY VALIDATION FAILED (debug mode - continuing anyway)"
-  echo "Full policy output:"
+  echo "Full policy list output:"
   echo "$POLICY_OUTPUT"
+  echo "Full policy get output (workload-can-read):"
+  echo "$POLICY_READ_OUTPUT"
+  echo "Full policy get output (workload-can-write):"
+  echo "$POLICY_WRITE_OUTPUT"
   echo "=========================================="
 else
   echo "Policy verification passed."

--- a/hack/bare-metal/startup/start.sh
+++ b/hack/bare-metal/startup/start.sh
@@ -79,6 +79,63 @@ fi
 # Your existing script continues here
 echo "Domain check passed. Continuing with the script..."
 
+# Preflight: make sure the SPIRE binaries this run needs are on PATH.
+# Failing here with clear guidance is far more helpful than a bare
+# "spire-server: command not found" surfacing later from the agent-token
+# or agent-start scripts. Only the binaries that the enabled steps actually
+# use are required, so external-SPIRE workflows that skip those steps are
+# not blocked.
+check_spire_binaries() {
+  local missing=()
+
+  # spire-server starts the server, generates the agent token, and
+  # registers entries.
+  if [ -z "$SPIKE_SKIP_SPIRE_SERVER_START" ] ||
+    [ -z "$SPIKE_SKIP_GENERATE_AGENT_TOKEN" ] ||
+    [ -z "$SPIKE_SKIP_REGISTER_ENTRIES" ]; then
+    if ! command -v spire-server >/dev/null 2>&1; then
+      missing+=("spire-server")
+    fi
+  fi
+
+  # spire-agent starts the SPIRE agent.
+  if [ -z "$SPIKE_SKIP_SPIRE_AGENT_START" ]; then
+    if ! command -v spire-agent >/dev/null 2>&1; then
+      missing+=("spire-agent")
+    fi
+  fi
+
+  if [ ${#missing[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  echo "" >&2
+  echo "Error: required SPIRE binaries were not found on your PATH:" >&2
+  for m in "${missing[@]}"; do
+    echo "  - $m" >&2
+  done
+  echo "" >&2
+  echo "The bare-metal dev environment needs the SPIRE server and agent" >&2
+  echo "binaries on your PATH." >&2
+  echo "" >&2
+  echo "To build and install them (SPIRE v1.11.2 into /usr/local/bin):" >&2
+  echo "  ./hack/bare-metal/build/build-spire.sh" >&2
+  echo "" >&2
+  echo "If you already have them elsewhere, add that directory to PATH:" >&2
+  echo "  export PATH=\"/path/to/spire/bin:\$PATH\"" >&2
+  echo "" >&2
+  echo "Then verify with:" >&2
+  echo "  command -v spire-server spire-agent" >&2
+  echo "" >&2
+  echo "See https://spike.ist/development/bare-metal/ for details." >&2
+  return 1
+}
+
+if ! check_spire_binaries; then
+  echo "SPIRE preflight check failed. Exiting..." >&2
+  exit 1
+fi
+
 # Helpers
 source ./hack/lib/bg.sh
 

--- a/hack/bare-metal/startup/start.sh
+++ b/hack/bare-metal/startup/start.sh
@@ -170,37 +170,81 @@ fi
 # the build produces them. Failing here, before any SPIRE or SPIKE
 # process starts, is far more helpful than a bare "spike: command not
 # found" surfacing halfway through startup.
+#
+# Each name must also resolve to the binary in ./bin, not to an
+# unrelated tool that happens to share the name. The SPIRE entries pin
+# the exact binary path and hash (unix:path and unix:sha256 selectors),
+# so a lookalike elsewhere on PATH cannot obtain an identity and the
+# run fails in confusing ways later.
 check_spike_binaries() {
   local missing=()
+  local shadowed=()
+  local found
+  local failed=0
 
   for b in spike nexus keeper bootstrap demo; do
-    if ! command -v "$b" >/dev/null 2>&1; then
+    found="$(command -v "$b" 2>/dev/null)"
+    if [ -z "$found" ]; then
       missing+=("$b")
+    elif [ ! "$found" -ef "$(pwd)/bin/$b" ]; then
+      shadowed+=("$b -> $found")
     fi
   done
 
-  if [ ${#missing[@]} -eq 0 ]; then
-    echo "All required SPIKE binaries found on PATH."
-    return 0
+  if [ ${#missing[@]} -gt 0 ]; then
+    failed=1
+    echo "" >&2
+    echo "Error: required SPIKE binaries were not found on your PATH:" >&2
+    for m in "${missing[@]}"; do
+      echo "  - $m" >&2
+    done
+    echo "" >&2
+    echo "To build them into ./bin:" >&2
+    echo "  make build" >&2
+    echo "" >&2
+    echo "Then add the bin directory to your PATH:" >&2
+    echo "  export PATH=\"\$PATH:$(pwd)/bin\"" >&2
+    echo "" >&2
+    echo "Then verify with:" >&2
+    echo "  command -v spike nexus keeper bootstrap demo" >&2
+    echo "" >&2
+    echo "See https://spike.ist/development/bare-metal/ for details." >&2
   fi
 
-  echo "" >&2
-  echo "Error: required SPIKE binaries were not found on your PATH:" >&2
-  for m in "${missing[@]}"; do
-    echo "  - $m" >&2
-  done
-  echo "" >&2
-  echo "To build them into ./bin:" >&2
-  echo "  make build" >&2
-  echo "" >&2
-  echo "Then add the bin directory to your PATH:" >&2
-  echo "  export PATH=\"\$PATH:$(pwd)/bin\"" >&2
-  echo "" >&2
-  echo "Then verify with:" >&2
-  echo "  command -v spike nexus keeper bootstrap demo" >&2
-  echo "" >&2
-  echo "See https://spike.ist/development/bare-metal/ for details." >&2
-  return 1
+  if [ ${#shadowed[@]} -gt 0 ]; then
+    local label="Error"
+    if [ -n "$SPIKE_SKIP_REGISTER_ENTRIES" ]; then
+      label="Warning"
+    fi
+    echo "" >&2
+    echo "$label: PATH resolves these commands outside $(pwd)/bin:" >&2
+    for s in "${shadowed[@]}"; do
+      echo "  - $s" >&2
+    done
+    echo "" >&2
+    echo "SPIKE registers its workloads with SPIRE by exact binary" >&2
+    echo "path and hash, so the binaries above cannot obtain an" >&2
+    echo "identity even if they are copies of the SPIKE binaries." >&2
+    echo "" >&2
+    echo "Give $(pwd)/bin precedence for this shell:" >&2
+    echo "  export PATH=\"$(pwd)/bin:\$PATH\"" >&2
+    echo "" >&2
+    echo "Or remove/rename the conflicting binaries." >&2
+    if [ -z "$SPIKE_SKIP_REGISTER_ENTRIES" ]; then
+      failed=1
+    else
+      echo "" >&2
+      echo "WARNING: continuing because SPIKE_SKIP_REGISTER_ENTRIES" >&2
+      echo "is set; make sure your registered entries match the" >&2
+      echo "binaries listed above." >&2
+    fi
+  fi
+
+  if [ $failed -eq 0 ] && [ ${#shadowed[@]} -eq 0 ]; then
+    echo "All required SPIKE binaries found on PATH."
+  fi
+
+  return $failed
 }
 
 if ! check_spike_binaries; then

--- a/makefiles/BareMetal.mk
+++ b/makefiles/BareMetal.mk
@@ -30,6 +30,14 @@ start-privileged:
 build:
 	./hack/bare-metal/build/build-spike.sh
 
+.PHONY: build-spire
+# Builds and installs the SPIRE server and agent binaries that the
+# bare-metal dev environment needs (SPIRE v1.11.2 into /usr/local/bin).
+# Requires Go and sudo. Run this once before `make start` if
+# spire-server/spire-agent are not already on your PATH.
+build-spire:
+	./hack/bare-metal/build/build-spire.sh
+
 # Registry an entry to the SPIRE server for the demo app.
 demo-register-entry:
 	./examples/consume-secrets/demo-register-entry.sh


### PR DESCRIPTION
What started as "fail fast when SPIRE binaries are missing" turned into
a chain of finds, each surfaced by the previous fix letting `make start`
run further. The branch hardens the bare-metal startup path end to end
and fixes a real regression in Nexus that made `spike policy get` and
`spike policy delete` unusable.

## The `make start` preflight (bare-metal harness)

- **SPIRE binaries** (`a70c80b`, `861c86c`, `526ee14`): `start.sh` now
  checks for `spire-server`/`spire-agent` on PATH up front and points
  at the new `make build-spire` target instead of failing mid-run with
  a bare "command not found". `build-spire.sh` clones into a temp
  directory and cleans up after itself (the leftover `./spire` clone
  used to break `make audit`).
- **SPIKE binaries** (`d683ce8`): the same treatment for `spike`,
  `nexus`, `keeper`, `bootstrap`, and `demo`. The check runs right
  after the build step (on a fresh clone the binaries do not exist
  earlier) and fails with concrete guidance: `make build`, a
  copy-pasteable `export PATH` line, and a verify command.
- **PATH shadowing** (`314ae6e`): the binary names are generic enough
  to collide with tools already on PATH, and the docs recommend
  appending the repo's `bin` to PATH, so an existing lookalike wins
  silently. Because the SPIRE entries pin the exact binary path and
  hash (`unix:path`, `unix:sha256`), a shadowed binary cannot obtain an
  identity and the run fails later in confusing ways. The preflight now
  verifies each name resolves to `./bin/<name>` (same-file test, so
  symlinks are fine) and fails fast naming the conflicting paths. When
  `SPIKE_SKIP_REGISTER_ENTRIES` is set the entries may legitimately
  point elsewhere, so the mismatch downgrades to a warning.

Keeping PATH-based invocation is deliberate: binaries on PATH are the
user-facing convenience, and the harness sharing that resolution keeps
one consistent story. The preflight only makes the failure modes loud.

## The policy regression (Nexus)

`0971260` — since #292 policies are keyed solely by name, and the `ID`
field of `PolicyReadRequest`/`PolicyDeleteRequest` carries the policy
name (the route handlers already treat it that way). The request
guards, however, still validated that field with
`net.RespondErrOnBadPolicyID`, which enforces UUID format, so every
`spike policy get <name>` and `spike policy delete <name>` came back
"400 Bad Request" before reaching its handler. The guards now use
`net.RespondErrOnBadName`, the same validator the put guard applies on
create. Validation stays in force; only the enforced format changes.

## Cleanups the regression hunt surfaced

- `837e0db` (pilot): the human formatters for `spike policy list` and                    `spike policy get` printed a vestigial `ID:` line, always empty since                  #292. Removed, tests updated, and the stale `list` doc example
  rewritten (it showed fields the list endpoint never returns).
- `7795eea` (harness): the policy checks in `start.sh` grepped for
  output formats that predate both #274 and #292 (tabular `ID NAME`
  header, `Permissions:` lines that `list` never prints). They failed
  on every run, masked by the debug-mode "continuing anyway" path. The
  validation now expects `Name: <policy>` blocks from `list` and
  verifies permissions through `spike policy get`, which also exercises
  the fixed get-by-name path end to end.

## Testing

- Full `make audit` and `make test` pass on every commit.
- The preflight functions were exercised directly in all paths:
  missing binaries, shadowed binaries (fatal and warn variants), and
  clean pass.
- The get-by-name regression was reproduced against a live bare-metal
  environment (`Error: Invalid request.`) before the fix.
## Follow-ups (not in this PR)
- SDK issue #250: rename the `ID` field to `Name` in policy                              request/response types; the empty `"id"` in JSON/YAML output goes
  away with it.                                                                        - The sqlite state tests use the real `~/.spike/data/spike.db` and
  delete it, which breaks a concurrently running bare-metal environment                  (and vice versa). They should use `t.TempDir()`.