### PR TITLE
chore: bump go directive to 1.26.5 to match the toolchain

### DIFF
--- a/dockerfiles/bootstrap.Dockerfile
+++ b/dockerfiles/bootstrap.Dockerfile
@@ -2,7 +2,7 @@
 #  \\\\\ Copyright 2024-present SPIKE contributors.
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM golang:1.25.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/dockerfiles/demo.Dockerfile
+++ b/dockerfiles/demo.Dockerfile
@@ -2,7 +2,7 @@
 #  \\\\\ Copyright 2024-present SPIKE contributors.
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM golang:1.25.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/dockerfiles/keeper.Dockerfile
+++ b/dockerfiles/keeper.Dockerfile
@@ -2,7 +2,7 @@
 #  \\\\\ Copyright 2024-present SPIKE contributors.
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM golang:1.25.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/dockerfiles/nexus.Dockerfile
+++ b/dockerfiles/nexus.Dockerfile
@@ -2,7 +2,7 @@
 #  \\\\\ Copyright 2024-present SPIKE contributors.
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM golang:1.25.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/dockerfiles/pilot.Dockerfile
+++ b/dockerfiles/pilot.Dockerfile
@@ -2,7 +2,7 @@
 #  \\\\\ Copyright 2024-present SPIKE contributors.
 # \\\\\\\ SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM golang:1.25.5 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/spiffe/spike
 
-go 1.25.5
-
-toolchain go1.26.5
+go 1.26.5
 
 require (
 	github.com/cloudflare/circl v1.6.3


### PR DESCRIPTION
The go directive lagged at 1.25.5 while the toolchain was pinned to
go1.26.5, which was needlessly confusing. Set a single `go 1.26.5`
directive and drop the now-redundant toolchain line, giving one source
of truth for the language/toolchain version.

CI reads go-version-file: go.mod, so it picks up 1.26.5 automatically.
Build, test, and audit all pass.

Spec: TBD
Signed-off-by: Volkan Özçelik <volkan.ozcelik@broadcom.com>
